### PR TITLE
defining isdigit in midi.c

### DIFF
--- a/src/main/c/midi.c
+++ b/src/main/c/midi.c
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "smf.h"
 #include "midi.h"
+#include <ctype.h>
 
 int
 strcmp_min(char *s1, char *s2) {


### PR DESCRIPTION
Including ctype.h in midi.c in order to defines isdigit()