### PR TITLE
Make the code PEP8 compliant.

### DIFF
--- a/src/main/python/linuxband.py.in
+++ b/src/main/python/linuxband.py.in
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -16,11 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import logging
-import pygtk
-pygtk.require("2.0")
+import sys
+
 import gobject
+import pygtk
+
+pygtk.require("2.0")
+
 
 # substituted by autoconf
 PACKAGE_NAME = "@PACKAGE_NAME@"
@@ -35,6 +40,7 @@ PKG_LIB_DIR = "@pkglibdir@"
 # python version
 PYTHON_MAJOR = 2
 PYTHON_MINOR = 5
+
 
 def main():
     if not check_python_version():
@@ -62,9 +68,10 @@ def main():
     Glob.CONSOLE_LOG_LEVEL = console_log_level
     Logger.initLogging(console_log_level)
     logging.debug("%s %s" % (PACKAGE_NAME, PACKAGE_VERSION))
-	# start the gui
+    # start the gui
     from linuxband.gui.gui import Gui
     Gui()
+
 
 def check_python_version():
     if sys.version_info[0] != PYTHON_MAJOR or sys.version_info[1] < PYTHON_MINOR:
@@ -72,6 +79,7 @@ def check_python_version():
         print "Found Python version %s" % sys.version
         return False
     return True
+
 
 if __name__ == "__main__":
     main()

--- a/src/main/python/linuxband/__init__.py
+++ b/src/main/python/linuxband/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/config.py
+++ b/src/main/python/linuxband/config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,8 +19,9 @@
 
 import ConfigParser
 import logging
-from linuxband.glob import Glob
 import os
+
+from linuxband.glob import Glob
 
 
 class Config(object):
@@ -47,7 +50,7 @@ class Config(object):
             try:
                 logging.debug("Opening config")
                 self.__config.read(Config.__rc_file)
-            except:
+            except IOError:
                 logging.exception("Error reading configuration file '%s', loading defaults." % Config.__rc_file)
                 self.__load_default_config()
         else:
@@ -66,7 +69,7 @@ class Config(object):
                 self.__config.write(out_file)
             finally:
                 out_file.close()
-        except:
+        except IOError:
             logging.exception("Unable to save configuration file '" + fname + "'")
 
     def get_work_dir(self):
@@ -127,7 +130,7 @@ class Config(object):
         try:
             self.__config.read(Config.__default_config)
             self.set_work_dir(Config.__home_dir)
-        except:
+        except IOError:
             logging.exception("Failed to read default configuration from '" + Config.__default_config + "'")
 
     def __ensure_dir(self, newdir):
@@ -138,6 +141,6 @@ class Config(object):
             return True
         try:
             os.mkdir(newdir)
-        except:
+        except OSError:
             logging.exception("Unable to create directory '" + newdir + "'")
         return False

--- a/src/main/python/linuxband/config.py
+++ b/src/main/python/linuxband/config.py
@@ -47,11 +47,11 @@ class Config(object):
 
     def load_config(self):
         if self.__ensure_dir(Glob.CONFIG_DIR):
+            logging.debug("Opening config")
             try:
-                logging.debug("Opening config")
                 self.__config.read(Config.__rc_file)
-            except IOError:
-                logging.exception("Error reading configuration file '%s', loading defaults." % Config.__rc_file)
+            except ConfigParser.Error as e:
+                logging.exception("Error reading configuration file '%s': %s.\nLoading defaults." % Config.__rc_file, e)
                 self.__load_default_config()
         else:
             self.__load_default_config()
@@ -64,13 +64,22 @@ class Config(object):
         fname = Config.__rc_file
         logging.info("Saving configuration to '" + fname + "'")
         try:
-            out_file = file(fname, 'w')
+            out_file = open(fname, 'w')
             try:
                 self.__config.write(out_file)
+            
+            except ConfigParser.Error as e:
+                logging.exception("Error writing configuration file '%s':\n%s", fname, e)
+            
             finally:
                 out_file.close()
-        except IOError:
-            logging.exception("Unable to save configuration file '" + fname + "'")
+        
+        except IOError as e:
+            logging.exception("Cannot open configuration file '%s' for writing:\n%s", fname, e.strerror)
+
+                
+            
+            
 
     def get_work_dir(self):
         return self.__config.get(Config.__SAVED, Config.__WORK_DIR)
@@ -130,8 +139,8 @@ class Config(object):
         try:
             self.__config.read(Config.__default_config)
             self.set_work_dir(Config.__home_dir)
-        except IOError:
-            logging.exception("Failed to read default configuration from '" + Config.__default_config + "'")
+        except ConfigParser.Error as e:
+            logging.exception("Failed to read default configuration from '%s':\n%s", Config.__default_config, e)
 
     def __ensure_dir(self, newdir):
         """
@@ -141,6 +150,6 @@ class Config(object):
             return True
         try:
             os.mkdir(newdir)
-        except OSError:
-            logging.exception("Unable to create directory '" + newdir + "'")
+        except OSError as e:
+            logging.exception("Unable to create directory '%s':\n%s", newdir, e.strerror)
         return False

--- a/src/main/python/linuxband/glob.py
+++ b/src/main/python/linuxband/glob.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -26,7 +28,7 @@ class Glob:
     A_DEF_GROOVE = "DEFGROOVE"
     A_DOC = "DOC"
     A_GROOVE = "GROOVE"
-    A_REMARK = "REMARK" # comment line with song title
+    A_REMARK = "REMARK"  # comment line with song title
     A_REPEAT = "REPEAT"
     A_REPEAT_END = "REPEATEND"
     A_REPEAT_ENDING = "REPEATENDING"
@@ -36,12 +38,12 @@ class Glob:
     A_UNKNOWN = "UNKNOWN"
 
     # list of supported events, order of Add event menulist
-    EVENTS = [ A_GROOVE, A_TEMPO, A_REPEAT, A_REPEAT_ENDING, A_REPEAT_END ]
+    EVENTS = [A_GROOVE, A_TEMPO, A_REPEAT, A_REPEAT_ENDING, A_REPEAT_END]
 
     OUTPUT_FILE_DEFAULT = "untitled.mma"
     UNTITLED_SONG_NAME = "Untitled Song"
 
-        # user's home dir - works for windows/unix/linux
+    # user's home dir - works for windows/unix/linux
     HOME_DIR = os.getenv('USERPROFILE') or os.getenv('HOME')
     CONFIG_DIR = HOME_DIR + '/.linuxband'
 
@@ -60,4 +62,3 @@ class Glob:
     LICENSE = ""
     PLAYER_PROGRAM = ""
     CONSOLE_LOG_LEVEL = None
-

--- a/src/main/python/linuxband/gui/__init__.py
+++ b/src/main/python/linuxband/gui/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/gui/about_dialog.py
+++ b/src/main/python/linuxband/gui/about_dialog.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -16,8 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from linuxband.gui.common import Common
+
 from linuxband.glob import Glob
+from linuxband.gui.common import Common
 
 
 class AboutDialog(object):
@@ -36,7 +39,7 @@ class AboutDialog(object):
                 license_text = infile.read()
             finally:
                 infile.close()
-        except:
+        except IOError:
             logging.exception("Unable to read license file '" + fname + "'")
         dialog.set_license(license_text)
         Common.connect_signals(glade, self)

--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -171,7 +171,7 @@ class ChordEntries(object):
 
         chord_names = []
         for c in base_ext:
-            for k, v in chordlist.iteritems():
+            for k in chordlist.iterkeys():
                 chord_names.append(c + k)
 
         chord_names.sort()

--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -15,9 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import gobject
+import gtk
+
 from gtk.gdk import CONTROL_MASK
+
 from linuxband.gui.common import Common
 from linuxband.mma.chord_table import chordlist
 
@@ -32,7 +36,8 @@ class ChordEntries(object):
 
     def refresh(self):
         """ Refresh chord entries. """
-        if self.__chord_sheet.is_cursor_on_bar_info(): return
+        if self.__chord_sheet.is_cursor_on_bar_info():
+            return
         barnum = self.__chord_sheet.get_current_bar_number()
 
         for entry in self.__entries:
@@ -42,7 +47,7 @@ class ChordEntries(object):
             chords = self.__song.get_data().get_bar_chords(barnum).get_chords()
             for i in range(len(chords)):
                 chord = chords[i][0]
-                if chord == '/': # don't show '/' as chord
+                if chord == '/':  # don't show '/' as chord
                     self.__entries[i].set_text('')
                 else:
                     self.__entries[i].set_text(chord)
@@ -52,8 +57,8 @@ class ChordEntries(object):
 
     def on_entry_key_release_event_callback(self, widget, event):
         key = event.keyval
-        if key == gtk.keysyms.Escape \
-            or (event.state & CONTROL_MASK and key == gtk.keysyms.bracketright):
+        if (key == gtk.keysyms.Escape
+                or (event.state & CONTROL_MASK and key == gtk.keysyms.bracketright)):
             # cancel chord editing
             self.__chord_sheet.render_current_field()
             self.refresh()
@@ -89,7 +94,7 @@ class ChordEntries(object):
         gobject.idle_add(self.__entries[num].grab_focus)
 
     def has_focus(self):
-        return self.__find_focused_entry() != None
+        return self.__find_focused_entry() is not None
 
     def hide(self):
         self.__hbox6.hide()
@@ -120,14 +125,16 @@ class ChordEntries(object):
     def __init_gui(self, glade, chord_names):
         Common.connect_signals(glade, self)
         self.__hbox6 = glade.get_widget("hbox6")
-        self.__entries = [ glade.get_widget("entry1"),
-                         glade.get_widget("entry2"),
-                         glade.get_widget("entry3"),
-                         glade.get_widget("entry4"),
-                         glade.get_widget("entry5"),
-                         glade.get_widget("entry6"),
-                         glade.get_widget("entry7"),
-                         glade.get_widget("entry8") ]
+        self.__entries = [
+            glade.get_widget("entry1"),
+            glade.get_widget("entry2"),
+            glade.get_widget("entry3"),
+            glade.get_widget("entry4"),
+            glade.get_widget("entry5"),
+            glade.get_widget("entry6"),
+            glade.get_widget("entry7"),
+            glade.get_widget("entry8")
+        ]
         # Initialize chord entry completion
         model = gtk.ListStore(str)
         for chord in chord_names:
@@ -152,10 +159,10 @@ class ChordEntries(object):
     def __get_chord_names(self):
         """
         Generate a list with all possible chords.
-        
+
         It is used for entry completion
         """
-        base = [ 'C', 'D', 'E', 'F', 'G', 'A', 'B' ]
+        base = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
         base_ext = []
         for c in base:
             base_ext.append(c)
@@ -164,7 +171,7 @@ class ChordEntries(object):
 
         chord_names = []
         for c in base_ext:
-            for k, v in chordlist.iteritems(): #@UnusedVariable
+            for k, v in chordlist.iteritems():
                 chord_names.append(c + k)
 
         chord_names.sort()

--- a/src/main/python/linuxband/gui/common.py
+++ b/src/main/python/linuxband/gui/common.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -26,5 +28,3 @@ class Common(object):
         for name, member in inspect.getmembers(obj):
             dicts[name] = member
         glade.signal_autoconnect(dicts)
-
-

--- a/src/main/python/linuxband/gui/events/__init__.py
+++ b/src/main/python/linuxband/gui/events/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -119,7 +119,7 @@ class EventGroove(object):
         """ Update description, author ... of the currently selected groove. """
         tb = self.__textbuffer2
         tb.set_text('')
-        start, end = tb.get_bounds()[0]
+        end = tb.get_bounds()[1]
         tb.insert_with_tags_by_name(end, gr[0] + '\n', 'fg_brown', 'bold')
         tb.insert(end, gr[1] + '\n\n')
         tb.insert_with_tags_by_name(end, gr[2] + '\n\n', 'bold')

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -15,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import gobject
 import gtk
 import pango
-import gobject
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventGroove(object):
@@ -36,7 +39,7 @@ class EventGroove(object):
 
     def on_treeview1_cursor_changed_callback(self, treeview):
         """ User clicked on the groove in the first column. """
-        path, column = treeview.get_cursor() #@UnusedVariable
+        path, column = treeview.get_cursor()
         gr = self.__groovesModel[path[0]]
         self.__treeview2.set_model(gr[6])
         self.__update_groove_info(gr)
@@ -44,9 +47,9 @@ class EventGroove(object):
 
     def on_treeview2_cursor_changed_callback(self, treeview):
         """ User clicked on the variation of groove. """
-        path, column = self.__treeview1.get_cursor() #@UnusedVariable
+        path, column = self.__treeview1.get_cursor()
         model = self.__groovesModel[path[0]][6]
-        path, column = self.__treeview2.get_cursor() #@UnusedVariable
+        path, column = self.__treeview2.get_cursor()
         gr = model[path[0]]
         self.__update_groove_info(gr)
         self.__update_groove_event(gr[0])
@@ -54,16 +57,20 @@ class EventGroove(object):
     def set_label_from_event(self, button, event):
         """ Sets the label of groove button correctly
             even if the event in the self.__song.get_data().get_bar_info(0) is missing. """
-        if event: button.set_label(BarInfo.get_groove_value(event))
-        else: button.set_label(EventGroove.__GROOVE_UNDEFINED)
+        if event:
+            button.set_label(BarInfo.get_groove_value(event))
+        else:
+            button.set_label(EventGroove.__GROOVE_UNDEFINED)
 
     def get_new_event(self):
         return self.__new_event
 
     def init_window(self, button, event):
         # hide back, forward, remove buttons
-        if button is self.__togglebutton1: self.__alignment12.hide()
-        else: self.__alignment12.show()
+        if button is self.__togglebutton1:
+            self.__alignment12.hide()
+        else:
+            self.__alignment12.show()
         self.__toggled_button = button
         self.__curr_event = event
         self.__new_event = None
@@ -81,13 +88,13 @@ class EventGroove(object):
         groove_window = glade.get_widget("grooveWindow")
         textview2 = glade.get_widget("textview2")
         self.__textbuffer2 = textview2.get_buffer()
-        # text colors      
+        # text colors
         colormap = groove_window.get_colormap()
         color = colormap.alloc_color('red')
         self.__textbuffer2.create_tag('fg_red', foreground_gdk=color)
-        color = colormap.alloc_color('brown');
+        color = colormap.alloc_color('brown')
         self.__textbuffer2.create_tag('fg_brown', foreground_gdk=color)
-        color = colormap.alloc_color('black');
+        color = colormap.alloc_color('black')
         self.__textbuffer2.create_tag('fg_black', foreground_gdk=color)
         self.__textbuffer2.create_tag("bold", weight=pango.WEIGHT_BOLD)
         self.__togglebutton1 = glade.get_widget("togglebutton1")
@@ -112,7 +119,7 @@ class EventGroove(object):
         """ Update description, author ... of the currently selected groove. """
         tb = self.__textbuffer2
         tb.set_text('')
-        start, end = tb.get_bounds() #@UnusedVariable
+        start, end = tb.get_bounds()
         tb.insert_with_tags_by_name(end, gr[0] + '\n', 'fg_brown', 'bold')
         tb.insert(end, gr[1] + '\n\n')
         tb.insert_with_tags_by_name(end, gr[2] + '\n\n', 'bold')

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -39,7 +39,7 @@ class EventGroove(object):
 
     def on_treeview1_cursor_changed_callback(self, treeview):
         """ User clicked on the groove in the first column. """
-        path, column = treeview.get_cursor()
+        path = treeview.get_cursor()[0]
         gr = self.__groovesModel[path[0]]
         self.__treeview2.set_model(gr[6])
         self.__update_groove_info(gr)
@@ -47,9 +47,9 @@ class EventGroove(object):
 
     def on_treeview2_cursor_changed_callback(self, treeview):
         """ User clicked on the variation of groove. """
-        path, column = self.__treeview1.get_cursor()
+        path = self.__treeview1.get_cursor()[0]
         model = self.__groovesModel[path[0]][6]
-        path, column = self.__treeview2.get_cursor()
+        path = self.__treeview2.get_cursor()[0]
         gr = model[path[0]]
         self.__update_groove_info(gr)
         self.__update_groove_event(gr[0])
@@ -119,7 +119,7 @@ class EventGroove(object):
         """ Update description, author ... of the currently selected groove. """
         tb = self.__textbuffer2
         tb.set_text('')
-        start, end = tb.get_bounds()
+        start, end = tb.get_bounds()[0]
         tb.insert_with_tags_by_name(end, gr[0] + '\n', 'fg_brown', 'bold')
         tb.insert(end, gr[1] + '\n\n')
         tb.insert_with_tags_by_name(end, gr[2] + '\n\n', 'bold')

--- a/src/main/python/linuxband/gui/events/repeat.py
+++ b/src/main/python/linuxband/gui/events/repeat.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,6 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 
 class EventRepeat(object):
 

--- a/src/main/python/linuxband/gui/events/repeat_end.py
+++ b/src/main/python/linuxband/gui/events/repeat_end.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -16,9 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventRepeatEnd(object):
@@ -31,7 +34,8 @@ class EventRepeatEnd(object):
     def on_comboboxentry1_changed_callback(self, widget):
         """ RepeatEnd value changed. """
         # called also when initializing the entries list
-        if not self.__toggled_button: return
+        if not self.__toggled_button:
+            return
         try:
             i = int(widget.child.get_text())
         except ValueError:
@@ -45,8 +49,10 @@ class EventRepeatEnd(object):
     def set_label_from_event(self, button, event):
         """ Sets the label of RepeatEnd button when the count has changed. """
         count = BarInfo.get_repeat_end_value(event)
-        if count == "2": label = "RepeatEnd"
-        else: label = "RepeatEnd " + count
+        if count == "2":
+            label = "RepeatEnd"
+        else:
+            label = "RepeatEnd " + count
         button.set_label(label)
 
     def get_new_event(self):

--- a/src/main/python/linuxband/gui/events/repeat_ending.py
+++ b/src/main/python/linuxband/gui/events/repeat_ending.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -16,9 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventRepeatEnding(object):
@@ -32,7 +35,8 @@ class EventRepeatEnding(object):
     def on_comboboxentry2_changed_callback(self, widget):
         """ RepeatEnding value changed """
         # called also when initializing the entries list
-        if not self.__toggled_button: return
+        if not self.__toggled_button:
+            return
         try:
             i = int(widget.child.get_text())
         except ValueError:
@@ -46,8 +50,10 @@ class EventRepeatEnding(object):
     def set_label_from_event(self, button, event):
         """ Sets the label of RepeatEnding button when the count was changed """
         count = BarInfo.get_repeat_ending_value(event)
-        if count == "2": label = "RepeatEnding"
-        else: label = "RepeatEnding " + count
+        if count == "2":
+            label = "RepeatEnding"
+        else:
+            label = "RepeatEnding " + count
         button.set_label(label)
 
     def get_new_event(self):

--- a/src/main/python/linuxband/gui/events/tempo.py
+++ b/src/main/python/linuxband/gui/events/tempo.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -16,8 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventTempo(object):
@@ -52,8 +54,10 @@ class EventTempo(object):
 
     def init_window(self, button, event):
         # hide back, forward, remove buttons
-        if button is self.__togglebutton2: self.__alignment15.hide()
-        else: self.__alignment15.show()
+        if button is self.__togglebutton2:
+            self.__alignment15.hide()
+        else:
+            self.__alignment15.show()
         self.__toggled_button = button
         self.__curr_event = event
         self.__new_event = None

--- a/src/main/python/linuxband/gui/events_bar.py
+++ b/src/main/python/linuxband/gui/events_bar.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import gobject
 import gtk
+
 from linuxband.glob import Glob
 from linuxband.gui.common import Common
 from linuxband.gui.events.groove import EventGroove
@@ -39,7 +42,7 @@ class EventsBar(object):
         self.__toggle_window_close_recursive = False
         # original label on toggle button just before opening the window
         self.__toggled_button_label = None
-        # event which is being edited in the toggleWindow    
+        # event which is being edited in the toggleWindow
         self.__curr_event = None
         self.__grooves = grooves
         self.__gui = gui
@@ -82,9 +85,9 @@ class EventsBar(object):
         self.__remove_from_triples(self.__toggled_triple[0])
         # remove button and close the window
         self.__hbox8.remove(self.__toggled_triple[0])
-        self.__toggle_window_close() # deletes the self.__toggled_triple
+        self.__toggle_window_close()  # deletes the self.__toggled_triple
         self.__refresh_globals()
-        self.__gui.refresh_current_field() # repetition
+        self.__gui.refresh_current_field()  # repetition
 
     def add_event_clicked_callback(self, button):
         """ Add event button pressed. """
@@ -102,7 +105,8 @@ class EventsBar(object):
                 # some other button is toggled
                 self.__toggle_window_close()
             for triple in self.__triples:
-                if triple[0] is button: break
+                if triple[0] is button:
+                    break
             self.__toggled_button_label = button.get_label()
             if button is self.__togglebutton1:
                 self.__curr_event = self.__song.get_data().get_bar_info(0).get_groove()
@@ -136,12 +140,14 @@ class EventsBar(object):
         else:
             self.__toggle_window_close(False)
             if button in [self.__togglebutton1, self.__togglebutton2]:
-                if not self.__curr_event: self.__song.get_data().get_bar_info(0).add_event(newEvent)
-                else: self.__song.get_data().get_bar_info(0).replace_event(self.__curr_event, newEvent)
+                if not self.__curr_event:
+                    self.__song.get_data().get_bar_info(0).add_event(newEvent)
+                else:
+                    self.__song.get_data().get_bar_info(0).replace_event(self.__curr_event, newEvent)
             else:
                 barNum = self.__gui.get_current_bar_number()
                 self.__song.get_data().get_bar_info(barNum).replace_event(self.__curr_event, newEvent)
-            self.refresh_all() # global groove or global tempo could have been changed
+            self.refresh_all()  # global groove or global tempo could have been changed
 
     def main_window_configure_event_callback(self, widget, event):
         """ Everytime the main window is moved or resised, move the toggle window with it. """
@@ -192,14 +198,16 @@ class EventsBar(object):
         # global buttons
         self.__eventGroove = EventGroove(glade, self.__grooves)
         self.__eventTempo = EventTempo(glade)
-        self.__triples.append([ self.__togglebutton1, groove_window, self.__eventGroove, None ])
-        self.__triples.append([ self.__togglebutton2, tempo_window, self.__eventTempo, None ])
+        self.__triples.append([self.__togglebutton1, groove_window, self.__eventGroove, None])
+        self.__triples.append([self.__togglebutton2, tempo_window, self.__eventTempo, None])
         # add event menu
-        event_items = { Glob.A_GROOVE: "Groove change",
-                      Glob.A_TEMPO: "Tempo change",
-                      Glob.A_REPEAT: "Repeat",
-                      Glob.A_REPEAT_ENDING: "RepeatEnding",
-                      Glob.A_REPEAT_END: "RepeatEnd" }
+        event_items = {
+            Glob.A_GROOVE:        "Groove change",
+            Glob.A_TEMPO:         "Tempo change",
+            Glob.A_REPEAT:        "Repeat",
+            Glob.A_REPEAT_ENDING: "RepeatEnding",
+            Glob.A_REPEAT_END:    "RepeatEnd"
+        }
         self.__addEventMenu = gtk.Menu()
         menu = self.__addEventMenu
         for key in Glob.EVENTS:
@@ -208,21 +216,26 @@ class EventsBar(object):
             menu.append(item)
         menu.show_all()
         # for dynamic event creation
-        self.__event_windows = { Glob.A_GROOVE: groove_window,
-                              Glob.A_TEMPO: tempo_window,
-                              Glob.A_REPEAT: repeat_window,
-                              Glob.A_REPEAT_ENDING: repeat_ending_window,
-                              Glob.A_REPEAT_END: repeat_end_window }
+        self.__event_windows = {
+            Glob.A_GROOVE:        groove_window,
+            Glob.A_TEMPO:         tempo_window,
+            Glob.A_REPEAT:        repeat_window,
+            Glob.A_REPEAT_ENDING: repeat_ending_window,
+            Glob.A_REPEAT_END:    repeat_end_window
+        }
 
-        self.__event_window_handlers = { Glob.A_GROOVE: self.__eventGroove, # reusing already existing object
-                                      Glob.A_TEMPO: self.__eventTempo,
-                                      Glob.A_REPEAT: EventRepeat(glade),
-                                      Glob.A_REPEAT_ENDING: EventRepeatEnding(glade),
-                                      Glob.A_REPEAT_END: EventRepeatEnd(glade) }
+        self.__event_window_handlers = {
+            Glob.A_GROOVE:        self.__eventGroove,
+            Glob.A_TEMPO:         self.__eventTempo,
+            Glob.A_REPEAT:        EventRepeat(glade),
+            Glob.A_REPEAT_ENDING: EventRepeatEnding(glade),
+            Glob.A_REPEAT_END:    EventRepeatEnd(glade)
+        }
 
     def __refresh_events_bar(self):
         """ Refresh events bar """
-        if self.__gui.is_cursor_on_bar_chords(): return
+        if self.__gui.is_cursor_on_bar_chords():
+            return
         barNum = self.__gui.get_current_bar_number()
         box = self.__hbox8
         children = box.get_children()
@@ -249,7 +262,7 @@ class EventsBar(object):
         event = BarInfo.create_event(key)
         self.__song.get_data().get_bar_info(barNum).add_event(event)
         self.refresh_all()
-        self.__gui.refresh_current_field() # repetition
+        self.__gui.refresh_current_field()  # repetition
         # open the new event window
         for triple in self.__triples:
             if triple[3] is event:
@@ -258,24 +271,25 @@ class EventsBar(object):
 
     def __remove_from_triples(self, button):
         for triple in self.__triples:
-            if triple[0] is button: break
+            if triple[0] is button:
+                break
         if triple[0] is button:
             self.__triples.remove(triple)
 
     def __move_window_underneath(self, gtkwindow, widget):
         """ Move window to appear directly under the toggled button """
         rect = widget.get_allocation()
-        rect2 = self.__main_window.get_allocation() # (0, 0, 1100, 700)
+        rect2 = self.__main_window.get_allocation()  # (0, 0, 1100, 700)
 
-        # black magic to get the correct values into rect3 
+        # black magic to get the correct values into rect3
         gtkwindow.realize()
         gtkwindow.window.get_root_origin()
 
         rect3 = gtkwindow.get_allocation()
 
         # this has a side effect that x, y on the following line are set properly
-        x1, y1 = self.__main_window.window.get_root_origin() # decoration window  @UnusedVariable
-        x, y = self.__main_window.window.get_origin() # our window
+        x1, y1 = self.__main_window.window.get_root_origin()  # decoration window  @UnusedVariable
+        x, y = self.__main_window.window.get_origin()  # our window
 
         wx = min(x + rect.x, x + rect2.width - rect3.width)
         wy = y + rect.y + rect.height
@@ -283,22 +297,22 @@ class EventsBar(object):
         gtkwindow.move(wx, wy)
 
     def __get_widget_xy_position(self, widget, gtkwindow):
-        #""" Move window to appear directly under the toggle button """
+        # Move window to appear directly under the toggle button
         rect = widget.get_allocation()
-        rect2 = self.__main_window.get_allocation() # (0, 0, 1100, 700)
+        rect2 = self.__main_window.get_allocation()  # (0, 0, 1100, 700)
 
-        # black magic to get the correct values into rect3 
+        # black magic to get the correct values into rect3
         gtkwindow.realize()
         gtkwindow.window.get_root_origin()
 
         rect3 = gtkwindow.get_allocation()
 
         # this has a side effect that x, y on the following line are set properly
-        x1, y1 = self.__main_window.window.get_root_origin() # decoration window  @UnusedVariable
-        x, y = self.__main_window.window.get_origin() # our window
+        x1, y1 = self.__main_window.window.get_root_origin()  # decoration window  @UnusedVariable
+        x, y = self.__main_window.window.get_origin()  # our window
 
         wx = min(x + rect.x, x + rect2.width - rect3.width)
-        wy = y + rect.y #+ rect.height
+        wy = y + rect.y
 
         return (wx, wy)
 
@@ -315,9 +329,11 @@ class EventsBar(object):
 
     def __toggle_window_close(self, restoreLabel=True):
         """ Close toggle window """
-        if self.__toggle_window_close_recursive: return
+        if self.__toggle_window_close_recursive:
+            return
         if self.__toggled_triple:
-            if restoreLabel: self.__toggled_triple[0].set_label(self.__toggled_button_label)
+            if restoreLabel:
+                self.__toggled_triple[0].set_label(self.__toggled_button_label)
             self.__toggled_triple[1].hide()
             # this will invoke on_togglebutton_clicked and then this method recursive again!
             self.__toggle_window_close_recursive = True

--- a/src/main/python/linuxband/gui/gui_logger.py
+++ b/src/main/python/linuxband/gui/gui_logger.py
@@ -55,7 +55,7 @@ class GuiLogger(object):
             logging.Formatter.__init__(self, fmt, datefmt)
 
         def formatException(self, ei):
-            excType, excValue, excTraceback = ei
+            excType, excValue, _ = ei
             res = ''.join(traceback.format_exception_only(excType, excValue))
             if res[-1] == '\n':
                 res = res[:-1]

--- a/src/main/python/linuxband/gui/gui_logger.py
+++ b/src/main/python/linuxband/gui/gui_logger.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -29,13 +31,16 @@ class GuiLogger(object):
             self.__textBuffer = textBuffer
 
         def emit(self, record):
-            record.exc_text = None # is needed to formatException to be called
+            record.exc_text = None  # is needed to formatException to be called
 
-            if record.levelname == 'INFO': tag = 'fg_black'
-            elif record.levelname == 'WARNING': tag = 'fg_brown'
-            elif record.levelname == 'ERROR': tag = 'fg_red'
+            if record.levelname == 'INFO':
+                tag = 'fg_black'
+            elif record.levelname == 'WARNING':
+                tag = 'fg_brown'
+            elif record.levelname == 'ERROR':
+                tag = 'fg_red'
 
-            start, end = self.__textBuffer.get_bounds() #@UnusedVariable
+            start, end = self.__textBuffer.get_bounds()
             text = self.__textBuffer.get_text(start, end)
             eol = '' if text == '' else '\n'
 
@@ -50,7 +55,7 @@ class GuiLogger(object):
             logging.Formatter.__init__(self, fmt, datefmt)
 
         def formatException(self, ei):
-            excType, excValue, excTraceback = ei #@UnusedVariable
+            excType, excValue, excTraceback = ei
             res = ''.join(traceback.format_exception_only(excType, excValue))
             if res[-1] == '\n':
                 res = res[:-1]
@@ -68,9 +73,9 @@ class GuiLogger(object):
         colormap = textView.get_colormap()
         color = colormap.alloc_color('red')
         textBuffer.create_tag('fg_red', foreground_gdk=color)
-        color = colormap.alloc_color('brown');
+        color = colormap.alloc_color('brown')
         textBuffer.create_tag('fg_brown', foreground_gdk=color)
-        color = colormap.alloc_color('black');
+        color = colormap.alloc_color('black')
         textBuffer.create_tag('fg_black', foreground_gdk=color)
 
     @staticmethod
@@ -80,5 +85,5 @@ class GuiLogger(object):
         textBufferHandler = GuiLogger.__TextBufferHandler(textView, textBuffer)
         textBufferHandler.setLevel(logging.INFO)
         textBufferHandler.setFormatter(GuiLogger.__MyFormatter(guiFormat, dateFormat))
-        rootLogger = logging.getLogger();
+        rootLogger = logging.getLogger()
         rootLogger.addHandler(textBufferHandler)

--- a/src/main/python/linuxband/gui/preferences.py
+++ b/src/main/python/linuxband/gui/preferences.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -15,8 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from linuxband.gui.common import Common
 import gtk
+
+from linuxband.gui.common import Common
+
 
 class Preferences(object):
 
@@ -27,7 +31,7 @@ class Preferences(object):
         self.__init_gui(glade)
 
     def run(self):
-        self.__initWidgets();
+        self.__initWidgets()
         result = self.__preferencesdialog.run()
         self.__preferencesdialog.hide()
         if (result == gtk.RESPONSE_OK):

--- a/src/main/python/linuxband/gui/save_button_status.py
+++ b/src/main/python/linuxband/gui/save_button_status.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -24,12 +26,14 @@ class SaveButtonStatus(object):
         button = glade.get_widget("toolbutton9")
         menuitem = glade.get_widget("imagemenuitem3")
         mainwindow = glade.get_widget("mainWindow")
-        self.__sourceId = gobject.timeout_add(800, self.__refresh_save_button_status, song, button, menuitem, mainwindow)
+        self.__sourceId = gobject.timeout_add(
+            800, self.__refresh_save_button_status, song, button, menuitem, mainwindow
+        )
 
     def __refresh_save_button_status(self, song, button, menuitem, mainwindow):
         save_needed = song.get_data().is_save_needed()
         button.set_sensitive(save_needed)
         menuitem.set_sensitive(save_needed)
-        prefix = "*"  if save_needed else ""
+        prefix = "*" if save_needed else ""
         mainwindow.set_title(prefix + song.get_data().get_title() + " | Linux Band")
         return True

--- a/src/main/python/linuxband/gui/source_editor.py
+++ b/src/main/python/linuxband/gui/source_editor.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -15,11 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 import gobject
 import gtk
 import gtksourceview2
 import pango
-import logging
+
 from linuxband.glob import Glob
 
 
@@ -60,7 +64,7 @@ class SourceEditor(object):
             iter1 = buff.get_iter_at_line(line)
             iter2 = buff.get_iter_at_line(line + 1)
             buff.apply_tag_by_name("error", iter1, iter2)
-            # error marker    
+            # error marker
             it = buff.get_iter_at_line(line)
             buff.create_source_mark(None, self.ERROR_MARKER, it)
         self.__error_mark_pos = line

--- a/src/main/python/linuxband/logger.py
+++ b/src/main/python/linuxband/logger.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import logging
 import sys
+
 
 class Logger(object):
 

--- a/src/main/python/linuxband/midi/__init__.py
+++ b/src/main/python/linuxband/midi/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/mma/__init__.py
+++ b/src/main/python/linuxband/mma/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/mma/bar_chords.py
+++ b/src/main/python/linuxband/mma/bar_chords.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -26,7 +28,7 @@ class BarChords:
         self.__before_number = ''
         self.__number = None
         self.__after_number = ' '
-        self.__chords = [[ '/', '' ]] # one chord is always there
+        self.__chords = [['/', '']]  # one chord is always there
         self.__eol = '\n'
 
     def set_song_data(self, song_data):
@@ -63,9 +65,9 @@ class BarChords:
         return self.__eol
 
     def set_chord(self, beat_num, chord):
-        """ 
+        """
         Save one chord on given beat.
-        
+
         If chord == '' then actually delete the chord.
         """
         # [['Dm', ' '], ['/', ' '], ['AmzC@3.2', ' '], ['z!', '\n']]
@@ -73,42 +75,44 @@ class BarChords:
         song_data = self.__song_data
         if chord == '' and beat_num >= len(self.__chords):
             return
-        if beat_num + 1 < len(chords): # there's a chord after this beat
+        if beat_num + 1 < len(chords):  # there's a chord after this beat
             full_chord = chords[beat_num]
-            if not chord: chord = '/'
+            if not chord:
+                chord = '/'
             if full_chord[0] != chord:
                 full_chord[0] = chord
                 song_data.changed()
         else:
-            if not chord: # delete a chord
+            if not chord:  # delete a chord
                 full_chord = chords[beat_num]
-                if beat_num > 0: # there is some chord before us
+                if beat_num > 0:  # there is some chord before us
                     # possibly move trailing string from our chord to eol
                     self.__eol = ''.join(full_chord[1:]) + self.__eol
                     chords.pop(beat_num)
                     song_data.changed()
-                else: # the only chord on the line
+                else:  # the only chord on the line
                     if full_chord[0] != '/':
                         full_chord[0] = '/'
                         song_data.changed()
-            else: # add or replace chord
-                if beat_num < len(chords): # replace an existing chord
+            else:  # add or replace chord
+                if beat_num < len(chords):  # replace an existing chord
                     full_chord = chords[beat_num]
                     if full_chord[0] != chord:
                         full_chord[0] = chord
                         song_data.changed()
-                else: # append a chord
+                else:  # append a chord
                     last_full_chord = chords[len(chords) - 1]
                     if len(last_full_chord[1]) == len(last_full_chord[1].rstrip()):
                         last_full_chord[1] = last_full_chord[1] + ' '
-                    while len(chords) < beat_num: chords.append(['/', ' '])
+                    while len(chords) < beat_num:
+                        chords.append(['/', ' '])
                     chords.append([chord, ''])
                     song_data.changed()
 
     def get_as_string_list(self):
         res = []
         res.append(self.__before_number)
-        if self.get_number() != None:
+        if self.get_number() is not None:
             res.append(str(self.get_number()))
         res.append(self.__after_number)
         for full_chord in self.__chords:

--- a/src/main/python/linuxband/mma/bar_info.py
+++ b/src/main/python/linuxband/mma/bar_info.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import copy
 import logging
+
 from linuxband.glob import Glob
 
 
@@ -44,12 +47,12 @@ class BarInfo:
     def get_events(self):
         return self.__events
 
-    # methods used by ChordSheet    
+    # methods used by ChordSheet
     def has_events(self):
         return True if len(self.__events) > 0 else False
 
     def has_repeat_begin(self):
-        return self.__lookup_action(Glob.A_REPEAT) != None
+        return self.__lookup_action(Glob.A_REPEAT) is not None
 
     def has_repeat_end(self):
         return self.__lookup_action(Glob.A_REPEAT_ENDING) or self.__lookup_action(Glob.A_REPEAT_END)
@@ -68,7 +71,7 @@ class BarInfo:
         return self.__lines
 
     def add_event(self, line):
-        if line[0] in [ Glob.A_REPEAT_END, Glob.A_REPEAT_ENDING ]:
+        if line[0] in [Glob.A_REPEAT_END, Glob.A_REPEAT_ENDING]:
             self.insert_line(line)
         else:
             self.add_line(line)
@@ -137,11 +140,13 @@ class BarInfo:
 
     @staticmethod
     def create_event(eventTitle):
-        eventsInit = { Glob.A_GROOVE:       [ Glob.A_GROOVE, "Groove", " ", "50sRock", "\n" ],
-                       Glob.A_TEMPO:        [ Glob.A_TEMPO, "Tempo", " ", "120", "\n" ],
-                       Glob.A_REPEAT:       [ Glob.A_REPEAT, "Repeat", "\n" ],
-                       Glob.A_REPEAT_ENDING: [ Glob.A_REPEAT_ENDING, "RepeatEnding", "\n" ],
-                       Glob.A_REPEAT_END:    [ Glob.A_REPEAT_END, "RepeatEnd", "\n" ] }
+        eventsInit = {
+            Glob.A_GROOVE: [Glob.A_GROOVE, "Groove", " ", "50sRock", "\n"],
+            Glob.A_TEMPO:  [Glob.A_TEMPO, "Tempo", " ", "120", "\n"],
+            Glob.A_REPEAT: [Glob.A_REPEAT, "Repeat", "\n"],
+            Glob.A_REPEAT_ENDING: [Glob.A_REPEAT_ENDING, "RepeatEnding", "\n"],
+            Glob.A_REPEAT_END:    [Glob.A_REPEAT_END, "RepeatEnd", "\n"]
+        }
         return copy.deepcopy(eventsInit[eventTitle])
 
     @staticmethod
@@ -163,13 +168,13 @@ class BarInfo:
     @staticmethod
     def set_repeat_end_value(line, count):
         # example line: ['REPEATEND', 'RepeatEnd', ' ', '2', '\n']
-        if len(line) > 3: # there is already some number
+        if len(line) > 3:  # there is already some number
             if count == 2:
                 line.pop(2)
                 line.pop(2)
             else:
                 line[3] = count
-        else: # no number yet, example: ['REPEATEND', 'RepeatEnd', '\n']
+        else:  # no number yet, example: ['REPEATEND', 'RepeatEnd', '\n']
             if count != 2:
                 line.insert(2, count)
                 line.insert(2, ' ')

--- a/src/main/python/linuxband/mma/chord_table.py
+++ b/src/main/python/linuxband/mma/chord_table.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -36,423 +38,431 @@ reference manual.
 
 """
 
-C  = 0
-Cs = Db = 1
-D       = 2
-Ds = Eb = 3
-E  = Fb = 4
-Es = F  = 5
-Fs = Gb = 6
-G       = 7
-Gs = Ab = 8
-A  = Bbb= 9
-As = Bb = 10
-B  = Cb = 11
+C        =  0
+Cs = Db  =  1
+D        =  2
+Ds = Eb  =  3
+E  = Fb  =  4
+Es = F   =  5
+Fs = Gb  =  6
+G        =  7
+Gs = Ab  =  8
+A  = Bbb =  9
+As = Bb  = 10
+B  = Cb  = 11
 
 chordlist = {
-    'M':    ((C,    E,      G ),
-             (C, D, E, F, G, A, B),
-             "Major triad. This is the default and is used in  "
-             "the absense of any other chord type specification."),
+    'M':        ((C,    E,    G),
+                 (C, D, E, F, G, A, B),
+                 "Major triad. This is the default and is used in  "
+                 "the absence of any other chord type specification."),
 
-    '(b5)':  ((C,    E,      Gb ),
-             (C, D, E, F, Gb, A, B),
-             "Major triad with flat 5th."),
+    '(b5)':     ((C,    E,    Gb),
+                 (C, D, E, F, Gb, A, B),
+                 "Major triad with flat 5th."),
 
-    'add9': ((C,    E,    G,    D+12),
-             (C, D, E, F, G, A, D+12),
-             "Major chord plus 9th (no 7th.)"),
+    'add9':     ((C,    E,    G,    D + 12),
+                 (C, D, E, F, G, A, D + 12),
+                 "Major chord plus 9th (no 7th.)"),
 
-    'm':    ((C,    Eb,    G ),
-             (C, D, Eb, F, G, Ab, Bb),
-             "Minor triad."),
+    'm':        ((C,    Eb,    G),
+                 (C, D, Eb, F, G, Ab, Bb),
+                 "Minor triad."),
 
-    'mb5':    ((C,    Eb,       Gb ),
-             (C, D, Eb, F, Gb, Ab, Bb),
-             "Minor triad with flat 5th (aka dim)."),
+    'mb5':      ((C,    Eb,    Gb),
+                 (C, D, Eb, F, Gb, Ab, Bb),
+                 "Minor triad with flat 5th (aka dim)."),
 
-    'm#5':    ((C,    Eb,       Gs ),
-             (C, D, Eb, F, Gs, Ab, Bb),
-             "Minor triad with augmented 5th."),
+    'm#5':      ((C,    Eb,    Gs),
+                 (C, D, Eb, F, Gs, Ab, Bb),
+                 "Minor triad with augmented 5th."),
 
-    'm6':    ((C,    Eb,       G, A ),
-             (C, D, Eb, F, G, A, Bb),
-             "Minor 6th (flat 3rd plus a 6th)."),
+    'm6':       ((C,    Eb,    G, A),
+                 (C, D, Eb, F, G, A, Bb),
+                 "Minor 6th (flat 3rd plus a 6th)."),
 
-    'm6(add9)':    ((C, Eb, G, D+12, A+12),
-             (C, D, Eb, F, G, A, Bb),
-             "Minor 6th with added 9th. This is sometimes notated as a slash chord "
-             "in the form ``m6/9''." ),
+    'm6(add9)': ((C,    Eb,    G,           D + 12, A + 12),
+                 (C, D, Eb, F, G, A,  Bb),
+                 "Minor 6th with added 9th. This is sometimes notated as a "
+                 "slash chord in the form ``m6/9''."),
 
-    'm7':    ((C,    Eb,       G,      Bb ),
-             (C, D, Eb, F, G, Ab, Bb),
-             "Minor 7th (flat 3rd plus dominant 7th)."),
+    'm7':       ((C,    Eb,    G,     Bb),
+                 (C, D, Eb, F, G, Ab, Bb),
+                 "Minor 7th (flat 3rd plus dominant 7th)."),
 
-    'mM7':    ((C,    Eb,      G,      B ),
-             (C, D, Eb, F, G, Ab, B),
-             "Minor Triad plus Major 7th. You will also see this printed "
-             "as ``m(maj7)'', ``m+7'', ``min(maj7)'' and ``min$\sharp$7'' "
-             "(which \mma\ accepts); as well as the \mma\ \emph{invalid} "
-             "forms: ``-($\Delta$7)'', and ``min$\\natural$7''."),
-
-    'm+7b9':  ((C, Eb, Gs, Bb, Db+12),
-               (C, Db, Eb, F, Gs, Ab, Bb),
-               "Augmented minor 7 plus flat 9th."),
-
-    'm+7#9':  ((C, Eb, Gs, Bb, Ds+12),
-               (C, Ds, Eb, F, Gs, Ab, Bb),
-               "Augmented minor 7 plus sharp 9th."),
-    
-    'mM7(add9)': ((C, Eb, G, B, D+12),
+    'mM7':      ((C,    Eb,    G,     B),
                  (C, D, Eb, F, G, Ab, B),
-                 "Minor Triad plus Major 7th and 9th."),
+                 "Minor Triad plus Major 7th. You will also see this printed "
+                 "as ``m(maj7)'', ``m+7'', ``min(maj7)'' and ``min♯7'' "
+                 "(which mma accepts); as well as the mma invalid "
+                 "forms: ``-(Δ7)'', and ``min♮7''."),
 
-    'm7b5': ((C,    Eb,       Gb,       Bb ),
-             (C, D, Eb, F, Gb, Ab, Bb),
-             "Minor 7th, flat 5 (aka 1/2 diminished). "),
+    'm+7b9':    ((C,     Eb,     Gs,     Bb, Db + 12),
+                 (C, Db, Eb, F,  Gs, Ab, Bb),
+                 "Augmented minor 7 plus flat 9th."),
 
-    'm7b9': ((C,     Eb,    G,     Bb, Db+12 ),
-             (C, Db, Eb, F, G, Ab, Bb),
-             "Minor 7th with added flat 9th."),
+    'm+7#9':    ((C,     Eb,     Gs,     Bb, Ds + 12),
+                 (C, Ds, Eb, F,  Gs, Ab, Bb),
+                 "Augmented minor 7 plus sharp 9th."),
 
-    'm7#9': ((C,     Eb,    G,     Bb, Ds+12 ),
-             (C, Ds, Eb, F, G, Ab, Bb),
-             "Minor 7th with added sharp 9th."),
+    'mM7(add9)':    ((C,    Eb,    G,     B, D + 12),
+                     (C, D, Eb, F, G, Ab, B),
+                     "Minor Triad plus Major 7th and 9th."),
 
-    '7':    ((C,    E,      G,    Bb ),
-             (C, D, E, F, G, A, Bb),
-             "7th."),
+    'm7b5':     ((C,    Eb,    Gb,     Bb),
+                 (C, D, Eb, F, Gb, Ab, Bb),
+                 "Minor 7th, flat 5 (aka 1/2 diminished). "),
 
-    '7b5':    ((C,    E,      Gb,    Bb ),
-             (C, D, E, F, Gb, A, Bb),
-             "7th, flat 5."),
+    'm7b9':     ((C,     Eb,    G,     Bb, Db + 12),
+                 (C, Db, Eb, F, G, Ab, Bb),
+                 "Minor 7th with added flat 9th."),
 
-    'dim7': ((C,    Eb,       Gb,       Bbb ),
-             (C, D, Eb, F, Gb, Ab, Bbb ),    # missing 8th note
-             "Diminished seventh."),
-    
-    'dim7(addM7)': ((C, Eb, Gb, A, B),
-             (C, D, Eb, F, Gb, A, B),
-             "Diminished tirad with added Major 7th."),
+    'm7#9':     ((C,     Eb,    G,     Bb, Ds + 12),
+                 (C, Ds, Eb, F, G, Ab, Bb),
+                 "Minor 7th with added sharp 9th."),
 
-    'aug':    ((C,    E,      Gs ),
-             (C, D, E, F, Gs, A, B ),
-             "Augmented triad."),
+    '7':        ((C,    E,    G,    Bb),
+                 (C, D, E, F, G, A, Bb),
+                 "7th."),
 
-    '6':    ((C,    E,      G, A ),
-             (C, D, E, F, G, A, B),
-             "Major tiad with added 6th."),
+    '7b5':      ((C,    E,    Gb,    Bb),
+                 (C, D, E, F, Gb, A, Bb),
+                 "7th, flat 5."),
 
-    '6(add9)':    ((C,   E, G, D+12, A+12),
-             (C, D, E, F, G, A, B),
-             "6th with added 9th. This is sometimes notated as a slash chord "
-             "in the form ``6/9''."),
+    'dim7':     ((C,    Eb,    Gb,     Bbb),
+                 (C, D, Eb, F, Gb, Ab, Bbb),    # missing 8th note
+                 "Diminished seventh."),
 
-    'M7':    ((C,    E,    G,    B),
-             (C, D, E, F, G, A, B),
-             "Major 7th."),
+    'dim7(addM7)':  ((C,     Eb,    Gb, A, B),
+                     (C, D,  Eb, F, Gb, A, B),
+                     "Diminished triad with added Major 7th."),
 
-    'M7#5':    ((C,    E,    Gs,    B),
-             (C, D, E, F, Gs, A, B),
-             "Major 7th with sharp 5th."),
+    'aug':      ((C,    E,    Gs),
+                 (C, D, E, F, Gs, A, B),
+                 "Augmented triad."),
 
-    'M7b5': ((C,    E,      Gb,    B ),
-             (C, D, E, F, Gb, A, B ),
-             "Major 7th with a flat 5th."),
+    '6':        ((C,    E,    G, A),
+                 (C, D, E, F, G, A, B),
+                 "Major triad with added 6th."),
 
-    '9':    ((C,    E,    G,    Bb, D+12 ),
-             (C, D, E, F, G, A, Bb),
-             "7th plus 9th."),
+    '6(add9)':  ((C,    E,    G,        D + 12, A + 12),
+                 (C, D, E, F, G, A, B),
+                 "6th with added 9th. This is sometimes notated as a slash "
+                 "chord in the form ``6/9''."),
 
- 
+    'M7':       ((C,    E,    G,    B),
+                 (C, D, E, F, G, A, B),
+                 "Major 7th."),
 
-    '9b5':    ((C,    E,    Gb,    Bb, D+12 ),
-             (C, D, E, F, Gb, A, Bb),
-             "7th plus 9th with flat 5th."),
+    'M7#5':     ((C,    E,    Gs,    B),
+                 (C, D, E, F, Gs, A, B),
+                 "Major 7th with sharp 5th."),
 
-    'm9':    ((C,    Eb,       G,      Bb, D+12 ),
-             (C, D, Eb, F, G, Ab, Bb),
-             "Minor triad plus 7th and 9th."),
+    'M7b5':     ((C,    E,    Gb,    B),
+                 (C, D, E, F, Gb, A, B),
+                 "Major 7th with a flat 5th."),
 
-    'm7b5b9': ((C, Eb, Gb, Bb, Db+12),
-               (C, Db, Eb, F, Gb, Ab, Bb),
-               "Minor 7th with flat 5th and flat 9th."),
+    '9':        ((C,    E,    G,    Bb,  D + 12),
+                 (C, D, E, F, G, A, Bb),
+                 "7th plus 9th."),
 
-    'm9b5': ((C,    Eb,    Gb, Bb, D+12 ),
-             (C, D, Eb, F, Gb, Ab, Bb),
-             "Minor triad, flat 5, plus 7th and 9th."),
 
-    'm(sus9)':((C,      Eb,    G,     D+12 ),
-               (C, D, Eb, F, G, Ab, D+12),
-               "Minor triad plus 9th (no 7th)."),
 
-    'M9':    ((C,    E,    G,    B, D+12 ),
-             (C, D, E, F, G, A, B),
-             "Major 7th plus 9th."),
+    '9b5':      ((C,    E,    Gb,    Bb,  D + 12),
+                 (C, D, E, F, Gb, A, Bb),
+                 "7th plus 9th with flat 5th."),
 
-    'M9#11': ((C, E, G, B, D+12, Fs+12),
-              (C, D, E, Fs, G, A, B),
-              "Major 9th plus sharp 11th."),
+    'm9':       ((C,    Eb,    G,     Bb,  D + 12),
+                 (C, D, Eb, F, G, Ab, Bb),
+                 "Minor triad plus 7th and 9th."),
 
-    '7b9':    ((C,     E,    G,    Bb, Db+12 ),
-             (C, Db, E, F, G, A, Bb),
-             "7th with flat 9th."),
+    'm7b5b9':   ((C,     Eb,    Gb,     Bb,  Db + 12),
+                 (C, Db, Eb, F, Gb, Ab, Bb),
+                 "Minor 7th with flat 5th and flat 9th."),
 
-    '7#9':    ((C,     E,    G,    Bb, Ds+12 ),
-             (C, Ds, E, F, G, A, Bb),
-             "7th with sharp 9th."),
+    'm9b5':     ((C,    Eb,    Gb,     Bb, D + 12),
+                 (C, D, Eb, F, Gb, Ab, Bb),
+                 "Minor triad, flat 5, plus 7th and 9th."),
 
-    '7#9b13':    ((C,     E,    G,    Bb, Ds+12, Ab+12 ),
-             (C, Ds, E, F, G, Ab, Bb),
-             "7th with sharp 9th and flat 13th."),
+    'm(sus9)':  ((C,    Eb,    G,     D + 12),
+                 (C, D, Eb, F, G, Ab, D + 12),
+                 "Minor triad plus 9th (no 7th)."),
 
-    '7b5b9':((C,     E,    Gb,    Bb, Db+12 ),
-             (C, Db, E, F, Gb, A, Bb),
-             "7th with flat 5th and flat 9th."),
+    'M9':       ((C,    E,    G,    B, D + 12),
+                 (C, D, E, F, G, A, B),
+                 "Major 7th plus 9th."),
 
-    '7b5#9':((C,     E,    Gb,    Bb, Ds+12 ),
-             (C, Ds, E, F, Gb, A, Bb),
-             "7th with flat 5th and sharp 9th."),
+    'M9#11':    ((C,    E,     G,    B,  D + 12, Fs + 12),
+                 (C, D, E, Fs, G, A, B),
+                 "Major 9th plus sharp 11th."),
 
-    '7#5#9':((C,     E,    Gs,    Bb, Ds+12 ),
-             (C, Ds, E, F, Gs, A, Bb),
-             "7th with sharp 5th and sharp 9th."),
+    '7b9':      ((C,     E,    G,    Bb,  Db + 12),
+                 (C, Db, E, F, G, A, Bb),
+                 "7th with flat 9th."),
 
- 
-    'aug7': ((C,    E,    Gs,    Bb ),
-             (C, D, E, F, Gs, A, Bb),
-             "An augmented chord (raised 5th) with a dominant 7th."),
+    '7#9':      ((C,     E,    G,    Bb,  Ds + 12),
+                 (C, Ds, E, F, G, A, Bb),
+                 "7th with sharp 9th."),
 
-    'aug7b9':((C,     E,    Gs,    Bb, Db+12 ),
-              (C, Db, E, F, Gs, A, Bb),
-              "An augmented chord (raised 5th) with a dominant 7th and flat 9th."),
+    '7#9b13':   ((C,     E,    G,     Bb,  Ds + 12, Ab + 12),
+                 (C, Ds, E, F, G, Ab, Bb),
+                 "7th with sharp 9th and flat 13th."),
 
-    'aug7#9':((C,     E,    Gs,    Bb, Ds+12 ),
-              (C, Ds, E, F, Gs, A, Bb),
-              "An augmented chord (raised 5th) with a dominant 7th and sharp 9th."),
+    '7b5b9':    ((C,     E,    Gb,    Bb,  Db + 12),
+                 (C, Db, E, F, Gb, A, Bb),
+                 "7th with flat 5th and flat 9th."),
 
-    'aug9M7':((C,     E,    Gs,    B, D+12 ),
-              (C, D, E, F, Gs, A, B),
-              "An augmented chord (raised 5th) with a major 7th and 9th."),
+    '7b5#9':    ((C,     E,    Gb,    Bb,  Ds + 12),
+                 (C, Ds, E, F, Gb, A, Bb),
+                 "7th with flat 5th and sharp 9th."),
 
-    '+7b9#11': ((C, E, Gs, Bb, Db+12, Fs+12),
-                (C, Db, E, Fs, G, A, Bb),
-                "Augmented 7th with flat 9th and sharp 11th."),
+    '7#5#9':    ((C,     E,    Gs,    Bb,  Ds + 12),
+                 (C, Ds, E, F, Gs, A, Bb),
+                 "7th with sharp 5th and sharp 9th."),
 
-    'm+7b9#11':  ((C, Eb, Gs, Bb, Db+12, Fs+12),
-                (C, Db, Eb, Fs, Gs, A, Bb),
-                "Augmented minor 7th with flat 9th and sharp 11th."),
 
-    '11':    ((C,   C,    G,    Bb, D+12, F+12 ),
-             (C, D, E, F, G, A, Bb),
-             "9th chord plus 11th (3rd not voiced)."),
+    'aug7':     ((C,    E,    Gs,    Bb),
+                 (C, D, E, F, Gs, A, Bb),
+                 "An augmented chord (raised 5th) with a dominant 7th."),
 
-    'm11':    ((C,    Eb,    G,     Bb, D+12, F+12 ),
-             (C, D, Eb, F, G, Ab, Bb),
-             "9th with minor 3rd,  plus 11th."),
+    'aug7b9':   ((C,     E,    Gs,    Bb,  Db + 12),
+                 (C, Db, E, F, Gs, A, Bb),
+                 "An augmented chord (raised 5th) with a dominant 7th and "
+                 "flat 9th."),
 
-    'm7(add11)':    ((C,    Eb,    G,    Bb, F+12 ),
-             (C, D, Eb, F, G, Ab, Bb),
-             "Minor 7th  plus 11th."),
+    'aug7#9':   ((C,     E,    Gs,    Bb,  Ds + 12),
+                 (C, Ds, E, F, Gs, A, Bb),
+                 "An augmented chord (raised 5th) with a dominant 7th and "
+                 "sharp 9th."),
 
-    'm9#11':   ((C, Eb, G, Bb, D+12, Fs+12),
-                (C, D, Eb, Fs, G, A, Bb),
-                "Minor 7th plus 9th and sharp 11th."),
+    'aug9M7':   ((C,    E,    Gs,    B,  D + 12),
+                 (C, D, E, F, Gs, A, B),
+                 "An augmented chord (raised 5th) with a major 7th and 9th."),
 
-    'm7b9#11':  ((C, Eb, G, Bb, Db+12, Fs+12),
-                (C, Db, Eb, Fs, G, A, Bb),
-                "Minor 7th plus flat 9th and sharp 11th."),
+    '+7b9#11':  ((C,     E,     Gs,   Bb,  Db + 12, Fs + 12),
+                 (C, Db, E, Fs, G, A, Bb),
+                 "Augmented 7th with flat 9th and sharp 11th."),
 
-    'm7(add13)':    ((C,    Eb,    G,    Bb, A+12 ),
-             (C, D, Eb, F, G, A, Bb),
-             "Minor 7th  plus 13th."),
+    'm+7b9#11': ((C,     Eb,     Gs,    Bb,  Db + 12, Fs + 12),
+                 (C, Db, Eb, Fs, Gs, A, Bb),
+                 "Augmented minor 7th with flat 9th and sharp 11th."),
 
-    '11b9': ((C,     E,    G,    Bb, Db+12, F+12 ),
-             (C, Db, E, F, G, A, Bb),
-             "7th chord plus flat 9th and 11th."),
+    '11':       ((C,    E,    G,    Bb,  D + 12, F + 12),
+                 (C, D, E, F, G, A, Bb),
+                 "9th chord plus 11th (3rd not voiced)."),
 
-    '9#5':    ((C,    E,    Gs,    Bb, D+12 ),
-             (C, D, E, F, Gs, A, Bb),
-             "7th plus 9th with sharp 5th (same as aug9)."),
+    'm11':      ((C,    Eb,    G,     Bb,  D + 12, F + 12),
+                 (C, D, Eb, F, G, Ab, Bb),
+                 "9th with minor 3rd,  plus 11th."),
 
-    '9#11': ((C,    E,     G,    Bb, D+12, Fs+12 ),
-             (C, D, E, Fs, G, A, Bb),
-             "7th plus 9th and sharp 11th."),
+    'm7(add11)':    ((C,    Eb,    G,     Bb,  F + 12),
+                     (C, D, Eb, F, G, Ab, Bb),
+                     "Minor 7th  plus 11th."),
 
-    '7#9#11':((C,     E,     G,    Bb, Ds+12, Fs+12 ),
-              (C, Ds, E, Fs, G, A, Bb),
-              "7th plus sharp 9th and sharp 11th."),
+    'm9#11':    ((C,    Eb,     G,    Bb,  D + 12, Fs + 12),
+                 (C, D, Eb, Fs, G, A, Bb),
+                 "Minor 7th plus 9th and sharp 11th."),
 
-    '7b9#11': ((C,     E,     G,    Bb, Db+12, Fs+12 ),
-              (C, Db, E, Fs, G, A, Bb),
-              "7th plus flat 9th and sharp 11th."),
+    'm7b9#11':  ((C,     Eb,     G,    Bb,  Db + 12, Fs + 12),
+                 (C, Db, Eb, Fs, G, A, Bb),
+                 "Minor 7th plus flat 9th and sharp 11th."),
 
-    '7#11':((C,    E,     G,    Bb,  Fs+12 ),
-             (C, D, E, Fs, G, A, Bb),
-             "7th plus sharp 11th (9th omitted)."),
+    'm7(add13)':    ((C,    Eb,    G,    Bb, A + 12),
+                     (C, D, Eb, F, G, A, Bb),
+                     "Minor 7th  plus 13th."),
 
-    'M7#11':((C,    E,     G,    B,  Fs+12 ),
-             (C, D, E, Fs, G, A, B),
-             "Major 7th plus sharp 11th (9th omitted)."),
+    '11b9':     ((C,     E,    G,    Bb,  Db + 12, F + 12),
+                 (C, Db, E, F, G, A, Bb),
+                 "7th chord plus flat 9th and 11th."),
 
-    'm11b5': ((C, Eb, Gb, Bb, D+12, F+12),
-              (C, D, Eb, F, Gb, A, Bb),
-              "Minor 7th with flat 5th plus 11th."),
+    '9#5':      ((C,    E,    Gs,    Bb,  D + 12),
+                 (C, D, E, F, Gs, A, Bb),
+                 "7th plus 9th with sharp 5th (same as aug9)."),
+
+    '9#11':     ((C,    E,     G,    Bb,  D + 12, Fs + 12),
+                 (C, D, E, Fs, G, A, Bb),
+                 "7th plus 9th and sharp 11th."),
+
+    '7#9#11':   ((C,     E,     G,    Bb,  Ds + 12, Fs + 12),
+                 (C, Ds, E, Fs, G, A, Bb),
+                 "7th plus sharp 9th and sharp 11th."),
+
+    '7b9#11':   ((C,     E,     G,    Bb,  Db + 12, Fs + 12),
+                 (C, Db, E, Fs, G, A, Bb),
+                 "7th plus flat 9th and sharp 11th."),
+
+    '7#11':     ((C,    E,     G,    Bb,  Fs + 12),
+                 (C, D, E, Fs, G, A, Bb),
+                 "7th plus sharp 11th (9th omitted)."),
+
+    'M7#11':    ((C,    E,     G,    B,  Fs + 12),
+                 (C, D, E, Fs, G, A, B),
+                 "Major 7th plus sharp 11th (9th omitted)."),
+
+    'm11b5':    ((C,    Eb,    Gb,    Bb,  D + 12, F + 12),
+                 (C, D, Eb, F, Gb, A, Bb),
+                 "Minor 7th with flat 5th plus 11th."),
 
     # Sus chords. Not sure what to do with the associated scales. For
     # now just duplicating the 2nd or 3rd in the scale seems to make sense.
 
-    'sus4': ((C,    F,    G ),
-             (C, D, F, F, G, A, B),
-             "Suspended 4th, major triad with the 3rd raised half tone."),
+    'sus4':     ((C,    F,    G),
+                 (C, D, F, F, G, A, B),
+                 "Suspended 4th, major triad with the 3rd raised half tone."),
 
-    '7sus': ((C,    F,    G,    Bb ),
-             (C, D, F, F, G, A, Bb),
-             "7th with suspended 4th, dominant 7th with 3rd "
-             "raised half tone."),
+    '7sus':     ((C,    F,    G,    Bb),
+                 (C, D, F, F, G, A, Bb),
+                 "7th with suspended 4th, dominant 7th with 3rd "
+                 "raised half tone."),
 
-    '7susb9': ((C, F, G, Bb, Db+12),
-               (C, Db, F, F, G, A, Bb),
-               "7th with suspended 4th and flat 9th."),
+    '7susb9':   ((C,     F,    G,    Bb,  Db + 12),
+                 (C, Db, F, F, G, A, Bb),
+                 "7th with suspended 4th and flat 9th."),
 
-    'sus2': ((C,    D,    G ),
-             (C, D, D, F, G, A, B),
-             "Suspended 2nd, major triad with the major 2nd above the "
-             "root substituted for 3rd."),
+    'sus2':     ((C,    D,    G),
+                 (C, D, D, F, G, A, B),
+                 "Suspended 2nd, major triad with the major 2nd above the "
+                 "root substituted for 3rd."),
 
-    '7sus2':((C,    D,    G,    Bb ),
-             (C, D, D, F, G, A, Bb),
-             "A sus2 with dominant 7th added."),
+    '7sus2':    ((C,    D,    G,    Bb),
+                 (C, D, D, F, G, A, Bb),
+                 "A sus2 with dominant 7th added."),
 
-    'sus9': ((C,    F,    G,    Bb, D+12),
-             (C, D, F, F, G, A, Bb),
-             "7sus plus 9th."),
+    'sus9':     ((C,    F,    G,    Bb,  D + 12),
+                 (C, D, F, F, G, A, Bb),
+                 "7sus plus 9th."),
 
-    '13sus': ((C, F, G, Bb, D+12, A+12),
-               (C, D, F, F, G, A, Bb),
-               "7sus, plus 9th and 13th"),
+    '13sus':    ((C,    F,    G,    Bb,  D + 12, A + 12),
+                 (C, D, F, F, G, A, Bb),
+                 "7sus, plus 9th and 13th"),
 
-    '13susb9': ((C, F, G, Bb, Db+12, A+12),
-               (C, Db, F, F, G, A, Bb),
-               "7sus, plus flat 9th and 13th"),
+    '13susb9':  ((C,     F,    G,    Bb,  Db + 12, A + 12),
+                 (C, Db, F, F, G, A, Bb),
+                 "7sus, plus flat 9th and 13th"),
 
     # these chords should probably NOT have the 5th included,
     # but since a number of voicings depend on the 5th being
     # the third note of the chord, they're here.
 
-    '13':    ((C,    E,    G,    Bb, A+12),
-             (C, D, E, F, G, A, Bb),
-             "7th (including 5th) plus 13th (the 9th and 11th are not voiced)."),
+    '13':       ((C,    E,    G,    Bb,  A + 12),
+                 (C, D, E, F, G, A, Bb),
+                 "7th (including 5th) plus 13th (the 9th and 11th are "
+                 "not voiced)."),
 
-    '13b5':  ((C,    E,    Gb,    Bb, A+12),
-             (C, D, E, F, Gb, A, Bb),
-             "7th with flat 5th,  plus 13th (the 9th and 11th are not voiced)."),
+    '13b5':     ((C,    E,    Gb,    Bb,  A + 12),
+                 (C, D, E, F, Gb, A, Bb),
+                 "7th with flat 5th,  plus 13th (the 9th and 11th are "
+                 "not voiced)."),
 
-    '13#9':    ((C,    E,    G,    Bb, Ds+12,  A+12),
-             (C, Ds, E, F, G, A, Bb),
-             "7th (including 5th) plus 13th and sharp 9th (11th not voiced)."),
- 
-    '13b9':  ((C,    E,    G,    Bb, Db+12,  A+12),
-             (C, Db, E, F, G, A, Bb),
-             "7th (including 5th) plus 13th and flat 9th (11th not voiced)."),
+    '13#9':     ((C,     E,    G,    Bb,  Ds + 12,  A + 12),
+                 (C, Ds, E, F, G, A, Bb),
+                 "7th (including 5th) plus 13th and sharp 9th "
+                 "(11th not voiced)."),
 
-    'M13':   ((C,    E,    G,    B, A+12),
-             (C, D, E, F, G, A, B),
-             "Major 7th (including 5th) plus 13th (9th and  11th not voiced)."),
+    '13b9':     ((C,     E,    G,    Bb,  Db + 12,  A + 12),
+                 (C, Db, E, F, G, A, Bb),
+                 "7th (including 5th) plus 13th and flat 9th "
+                 "(11th not voiced)."),
 
-    'm13':   ((C, Eb, G, Bb, A+12),
-              (C, D, Eb, F, G, A, Bb),
-              "Minor 7th (including 5th) plus 13th (9th and 11th not voiced)."),
+    'M13':      ((C,    E,    G,    B,  A + 12),
+                 (C, D, E, F, G, A, B),
+                 "Major 7th (including 5th) plus 13th "
+                 "(9th and  11th not voiced)."),
 
-    '13#11': ((C,    E,    G,    Bb, Fs+12, A+12),
-             (C, D, E, Fs, G, A, Bb),
-             "7th plus sharp 11th and 13th (9th not voiced)."),
+    'm13':      ((C,    Eb,    G,    Bb,  A + 12),
+                 (C, D, Eb, F, G, A, Bb),
+                 "Minor 7th (including 5th) plus 13th "
+                 "(9th and 11th not voiced)."),
 
-    'M13#11': ((C,    E,    G,    B, Fs+12, A+12),
-             (C, D, E, Fs, G, A, B),
-             "Major 7th plus sharp 11th and 13th (9th not voiced)."),
+    '13#11':    ((C,    E,     G,    Bb,  Fs + 12, A + 12),
+                 (C, D, E, Fs, G, A, Bb),
+                 "7th plus sharp 11th and 13th (9th not voiced)."),
+
+    'M13#11':   ((C,    E,     G,    B,  Fs + 12, A + 12),
+                 (C, D, E, Fs, G, A, B),
+                 "Major 7th plus sharp 11th and 13th (9th not voiced)."),
 
     # Because some patterns assume that the 3rd note in a chord is a 5th,
-    # or a varient, we duplicate the root into the position of the 3rd ... and
-    # to make the sound even we duplicate the 5th into the 4th position as well.
+    # or a variant, we duplicate the root into the position of the 3rd ... and
+    # to make the sound even we duplicate the 5th into the 4th position as
+    # well.
 
-    '5':    ((C, C,    G, G ),
-             (C, D, E, F, G, A, B),
-             "Altered Fifth or Power Chord; root and 5th only."),
+    '5':        ((C, C,       G, G),
+                 (C, D, E, F, G, A, B),
+                 "Altered Fifth or Power Chord; root and 5th only."),
 
-    'omit3add9': ((C, C, G, D+12),
-               (C, D, E, F, G, A, Bb),
-               "Triad: root, 5th and 9th."),
+    'omit3add9':    ((C, C,       G,        D + 12),
+                     (C, D, E, F, G, A, Bb),
+                     "Triad: root, 5th and 9th."),
 
-    '7omit3': ((C, C, G, Bb),
-                (C, D, E, F, G, A, Bb),
-                "7th with unvoiced 3rd."),
+    '7omit3':   ((C, C,       G,    Bb),
+                 (C, D, E, F, G, A, Bb),
+                 "7th with unvoiced 3rd."),
 
-    'm7omit5': ((C, Eb, Bb),
+    'm7omit5':  ((C,    Eb,          Bb),
                  (C, D, Eb, F, G, A, Bb),
                  "Minor 7th with unvoiced 5th."),
 }
 
 
-""" Extend our table with common synomyns. These are real copies,
+""" Extend our table with common synonyms. These are real copies,
     not pointers. This is done so that a user redefine only affects
     the original.
 """
 
 aliases = (
-    ('aug9',     '9#5',      ''),
-    ('+9',       '9#5',      ''),
-    ('+9M7',     'aug9M7',   ''),
-    ('+M7',      'M7#5',     ''),
-    ('m(add9)',  'm(sus9)',  ''),
-    ('69',       '6(add9)',  ''),
-    ('m69',      'm6(add9)', ''),
-    ('m(b5)',    'mb5',      ''),
-    ('m7(b9)',   'm7b9',     ''),
-    ('m7(#9)',   'm7#9',     ''),
-    ('9+5',      '9#5',      ''),
-    ('m+5',      'm#5',      ''),
-    ('M6',       '6',        ''),
-    ('m7-5',     'm7b5',     ''),
-    ('m7(omit5)','m7omit5',   ''),
-    ('+',        'aug',      ''),
-    ('+7',       'aug7',     ''),
-    ('7(omit3)', '7omit3',   ''),
-    ('#5',       'aug',      ''),
-    ('7#5b9',    'aug7b9',   ''),
-    ('7-9',      '7b9',      ''),
-    ('7+9',      '7#9',      ''),
-    ('maj7',     'M7',       ''),
-    ('M7-5',     'M7b5',     ''),
-    ('M7+5',     'M7#5',     ''),
-    ('M7(add13)','13b9',     ''),
-    ('7alt',     '7b5b9',    ''),
-    ('7sus4',    '7sus',     ''),
-    ('7+',       'aug7',     ''),
-    ('7#5',      'aug7',     ''),
-    ('7+5',      'aug7',     ''),
-    ('7-5',      '7b5',      ''),
-    ('sus',      'sus4',     ''),
-    ('maj9',     'M9',       ''),
-    ('maj13',    'M13',      ''),
-    ('m(maj7)',  'mM7',      ''),
-    ('m+7',      'mM7',      ''),
-    ('min(maj7)','mM7',      ''),
-    ('min#7',    'mM7',      ''),
-    ('m#7',      'mM7',      ''),
-    ('dim',      'dim7',     'A dim7, not a triad!'),
-    ('9sus',     'sus9',     ''),
-    ('9-5',      '9b5',      ''),
-    ('dim3',     'mb5',      'Diminished triad (non-standard notation).'),
-    ('omit3(add9)','omit3add9', ''),
-    ('9sus4',    'sus9',     '')
-    )
+    ('aug9',        '9#5',      ''),
+    ('+9',          '9#5',      ''),
+    ('+9M7',        'aug9M7',   ''),
+    ('+M7',         'M7#5',     ''),
+    ('m(add9)',     'm(sus9)',  ''),
+    ('69',          '6(add9)',  ''),
+    ('m69',         'm6(add9)', ''),
+    ('m(b5)',       'mb5',      ''),
+    ('m7(b9)',      'm7b9',     ''),
+    ('m7(#9)',      'm7#9',     ''),
+    ('9+5',         '9#5',      ''),
+    ('m+5',         'm#5',      ''),
+    ('M6',          '6',        ''),
+    ('m7-5',        'm7b5',     ''),
+    ('m7(omit5)',   'm7omit5',  ''),
+    ('+',           'aug',      ''),
+    ('+7',          'aug7',     ''),
+    ('7(omit3)',    '7omit3',   ''),
+    ('#5',          'aug',      ''),
+    ('7#5b9',       'aug7b9',   ''),
+    ('7-9',         '7b9',      ''),
+    ('7+9',         '7#9',      ''),
+    ('maj7',        'M7',       ''),
+    ('M7-5',        'M7b5',     ''),
+    ('M7+5',        'M7#5',     ''),
+    ('M7(add13)',   '13b9',     ''),
+    ('7alt',        '7b5b9',    ''),
+    ('7sus4',       '7sus',     ''),
+    ('7+',          'aug7',     ''),
+    ('7#5',         'aug7',     ''),
+    ('7+5',         'aug7',     ''),
+    ('7-5',         '7b5',      ''),
+    ('sus',         'sus4',     ''),
+    ('maj9',        'M9',       ''),
+    ('maj13',       'M13',      ''),
+    ('m(maj7)',     'mM7',      ''),
+    ('m+7',         'mM7',      ''),
+    ('min(maj7)',   'mM7',      ''),
+    ('min#7',       'mM7',      ''),
+    ('m#7',         'mM7',      ''),
+    ('dim',         'dim7',     'A dim7, not a triad!'),
+    ('9sus',        'sus9',     ''),
+    ('9-5',         '9b5',      ''),
+    ('dim3',        'mb5',      'Diminished triad (non-standard notation).'),
+    ('omit3(add9)', 'omit3add9', ''),
+    ('9sus4',       'sus9',     '')
+)
 
-for a,b,d in aliases:
-    n=chordlist[b][0]
-    s=chordlist[b][1]
+for a, b, d in aliases:
+    n = chordlist[b][0]
+    s = chordlist[b][1]
     if not d:
-        d=chordlist[b][2]
+        d = chordlist[b][2]
 
     chordlist[a] = (n, s, d)
-

--- a/src/main/python/linuxband/mma/grooves.py
+++ b/src/main/python/linuxband/mma/grooves.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -15,14 +17,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import pickle
-import logging
 import fnmatch
+import logging
 import os
+import pickle
+
+import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.parse import parse
 from linuxband.mma.bar_info import BarInfo
+from linuxband.mma.parse import parse
 
 
 class Grooves(object):
@@ -51,7 +55,7 @@ class Grooves(object):
             return 1
         elif a == b:
             return 0
-        else: # x<y
+        else:  # x<y
             return -1
 
     def __create_grooves_model(self, grooves_list):
@@ -68,9 +72,9 @@ class Grooves(object):
                 march_sub_liststore.append(groove)
             elif index == 0 \
                     or not groove[0].upper().startswith(pgroove) \
-                    or groove[0].startswith('Metronome'):   # metronome hack    
+                    or groove[0].startswith('Metronome'):   # metronome hack
                 sub_liststore = gtk.ListStore(str, str, str, str, str, str)
-                grooves_model.append(groove + [ sub_liststore ])
+                grooves_model.append(groove + [sub_liststore])
                 pgroove = groove[0].upper()
                 # March hack
                 if groove[0] == 'March':
@@ -80,9 +84,9 @@ class Grooves(object):
         return grooves_model
 
     def __load_grooves(self):
-        """ 
+        """
         Load grooves from /usr/share/mma/lib/stdlib (configurable).
-        
+
         Sort grooves and store them in grooves_list
         Call __create_grooves_model()
         """
@@ -95,12 +99,13 @@ class Grooves(object):
         """
         Load grooves and recurse into subdirectories.
         """
-        for dirname, dirnames, filenames in os.walk(path): #@UnusedVariable            
+        for dirname, dirnames, filenames in os.walk(path):
             for name in filenames:
                 if fnmatch.fnmatch(name, '*.mma'):
                     full_name = os.path.join(dirname, name)
                     song_data = self.__parseGrooves(full_name)
-                    if not song_data: continue
+                    if not song_data:
+                        continue
                     song_bar_info = song_data.get_bar_info_all()
                     doc = author = time = ''
                     for line in song_bar_info[0].get_lines():
@@ -128,14 +133,14 @@ class Grooves(object):
             except ValueError:
                 logging.exception("Failed to parse the file.")
             mma_file.close()
-        except:
+        except IOError:
             logging.exception("Failed to load grooves from file '" + file_name + "'")
         return song_data
 
     def __load_grooves_from_cache(self):
         """
         Load grooves from file or cache.
-        
+
         Call createGroovesModel()
         """
         fname = Grooves.__grooves_cache_file
@@ -145,7 +150,7 @@ class Grooves(object):
                 grooves_list = pickle.load(infile)
             finally:
                 infile.close()
-        except:
+        except IOError:
             logging.exception("Unable to load grooves from cache '" + fname + "'")
             return
         logging.info("Loaded %d groove patterns from cache '%s'" % (len(grooves_list), fname))
@@ -163,5 +168,5 @@ class Grooves(object):
                 pickle.dump(grooves_list, outfile, True)
             finally:
                 outfile.close()
-        except:
+        except IOError:
             logging.exception("Unable to store grooves into cache '" + fname + "'")

--- a/src/main/python/linuxband/mma/parse.py
+++ b/src/main/python/linuxband/mma/parse.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -35,6 +37,7 @@ from linuxband.mma.song_data import SongData
 # File processing. Mostly jumps to pats
 ########################################
 
+
 def parse(inpath):
     """
     Process a mma input file.
@@ -51,7 +54,7 @@ def parse(inpath):
 
         # EOF
         if not curline:
-            song_bar_info.append(bar_info) # song_bar_info has always one element more then song_bar_chords
+            song_bar_info.append(bar_info)  # song_bar_info has always one element more then song_bar_chords
             song_bar_count = bar_number
             return SongData(song_bar_info, song_bar_chords, song_bar_count)
 
@@ -61,18 +64,17 @@ def parse(inpath):
 
         # empty line
         if curline.rstrip('\n').strip() == '':
-            bar_info.add_line([Glob.A_UNKNOWN, curline]);
+            bar_info.add_line([Glob.A_UNKNOWN, curline])
             continue
 
-        l = curline.split()
+        line = curline.split()
 
         # line beginning with macro
-        if l[0][0] == '$':
+        if line[0][0] == '$':
             wline = get_wrapped_line(inpath, curline)
             wline.insert(0, Glob.A_UNKNOWN)
             bar_info.add_line(wline)
             continue
-
 
         """ Handle BEGIN and END here. This is outside of the Repeat/End
             and variable expand loops so SHOULD be pretty bullet proof.
@@ -90,11 +92,11 @@ def parse(inpath):
             begin[] stuff have to be here, in this order.
         """
 
-        action = l[0].upper()      # 1st arg in line
+        action = line[0].upper()      # 1st arg in line
 
         # parse BEGIN and END block
         if action == 'BEGIN':
-            block_action = l[1].upper()
+            block_action = line[1].upper()
             begin_block = parse_begin_block(inpath, curline)
             if block_action in supported_block_actions:
                 tokens = parse_supported_block_action(block_action, begin_block)
@@ -142,21 +144,23 @@ def parse(inpath):
 
         # track function BASS/DRUM/APEGGIO/CHORD ...
         if '-' in action:
-            trk_class, ext = action.split('-', 1) #@UnusedVariable
+            trk_class, ext = action.split('-', 1)
         else:
             trk_class = action
 
         if trk_class in trk_classes:
             # parsing track sequence ?
-            parse_seq = len(l) >= 1 and l[1].upper() == 'SEQUENCE'
+            parse_seq = len(line) >= 1 and line[1].upper() == 'SEQUENCE'
             wline = []
             while True:
                 wline.extend(get_wrapped_line(inpath, curline))
-                if not parse_seq: break
-                """ Count the number of { and } and if they don't match read more lines and 
+                if not parse_seq:
+                    break
+                """ Count the number of { and } and if they don't match read more lines and
                     append. If we get to the EOF then we're screwed and we error out. """
                 wline2 = ''.join(wline)
-                if wline2.count('{') == wline2.count('}'): break
+                if wline2.count('{') == wline2.count('}'):
+                    break
                 curline = inpath.readline()
                 if not curline:
                     raise ValueError("Reached EOF, Sequence {}s do not match")
@@ -170,11 +174,11 @@ def parse(inpath):
         if wline[0].replace('\\\n', '').strip() == '':
             # line is a comment or empty wrapped line
             act = Glob.A_REMARK if wline[1].strip() else Glob.A_UNKNOWN
-            bar_info.add_line([act , wline[0], wline[1]])
+            bar_info.add_line([act, wline[0], wline[1]])
             continue
 
-        l, eol = wline
-        ### Gotta be a chord data line!
+        line, eol = wline
+        # Gotta be a chord data line!
 
         """ A data line can have an optional bar number at the start
             of the line. Makes debugging input easier. The next
@@ -184,21 +188,21 @@ def parse(inpath):
 
         before_number = ''
         if action.isdigit():   # isdigit() matches '1', '1234' but not '1a'!
-            l2 = l.lstrip()
-            before_number_len = len(l) - len(l2)
-            before_number = l[0:before_number_len]
-            l = l2
-            numstr = l.split()[0]
+            l2 = line.lstrip()
+            before_number_len = len(line) - len(l2)
+            before_number = line[0:before_number_len]
+            line = l2
+            numstr = line.split()[0]
             bar_chords.set_number(int(numstr))
-            l = l[len(numstr):] # remove number
-            if len(l.strip()) == 0: # ignore empty lines
-                bar_info.add_line([ Glob.A_UNKNOWN, wline[0] + wline[1] ])
+            line = line[len(numstr):]  # remove number
+            if len(line.strip()) == 0:  # ignore empty lines
+                bar_info.add_line([Glob.A_UNKNOWN, wline[0] + wline[1]])
                 continue
 
         """ We now have a valid line. It'll look something like:
 
-            'Cm', '/', 'z', 'F#@4.5' { lyrics } [ solo ] * 2 
-            
+            'Cm', '/', 'z', 'F#@4.5' { lyrics } [ solo ] * 2
+
 
             Special processing in needed for 'z' options in chords. A 'z' can
             be of the form 'CHORDzX', 'z!' or just 'z'.
@@ -213,8 +217,8 @@ def parse(inpath):
         mismatched_lyrics = "Mismatched []s for lyrics found in chord line"
         while True:
             chars = ''
-            while i < len(l):
-                ch = l[i]
+            while i < len(line):
+                ch = line[i]
                 if ch == '{':
                     """ Extract solo(s) from line ... this is anything in {}s.
                         The solo data is pushed into RIFFs and discarded from
@@ -226,7 +230,7 @@ def parse(inpath):
                         NOTE: lyric.extract() inserts previously created
                         data from LYRICS SET and inserts the chord names
                         if that flag is active.
-        
+
                     """
                     lyrics_count += 1
                 elif ch == '}':
@@ -242,38 +246,38 @@ def parse(inpath):
                         be at the end of bar in the form '* xx'.
                     """
                     pass
-                elif ch in '\t\n\\ 0123456789': # white spaces, \ and repeat count
+                elif ch in '\t\n\\ 0123456789':  # white spaces, \ and repeat count
                     pass
-                elif solo_count == 0 and lyrics_count == 0: # found beginning of the chord
+                elif solo_count == 0 and lyrics_count == 0:  # found beginning of the chord
                     break
                 chars += ch
                 i += 1
-            if i == len(l): # no more chord is coming
+            if i == len(line):  # no more chord is coming
                 if solo_count != 0:
                     raise ValueError(mismatched_solo)
                 if lyrics_count != 0:
                     raise ValueError(mismatched_lyrics)
-                if after_number == None:
+                if after_number is None:
                     after_number = chars
                 else:
                     last_chord.append(chars)
                     ctable.append(last_chord)
                 break
-            else: # chord beginning
-                if after_number == None:
+            else:  # chord beginning
+                if after_number is None:
                     after_number = chars
                 else:
                     last_chord.append(chars)
                     ctable.append(last_chord)
                 chord_begin = i
                 # find the end of the chord
-                while i < len(l):
-                    if l[i] in '{}[]*\t\n\\ ':
+                while i < len(line):
+                    if line[i] in '{}[]*\t\n\\ ':
                         break
                     i += 1
                 # chord examples: '/', 'z', 'Am7@2', 'Am6zC@3'
-                c = l[chord_begin:i]
-                last_chord = [ c ]
+                c = line[chord_begin:i]
+                last_chord = [c]
         # the trailing string of the last chord can possibly include '\n' after which
         # it would be difficult to add further chords. Therefore move the trailing string
         # of the last chord to eol
@@ -296,7 +300,7 @@ def parse(inpath):
 def get_wrapped_line(inpath, curline):
     """
     Reads the whole wrapped line ('\' at the end) and stores it in a list.
-    
+
     The lines in the list are not modified and are the same as in the file
     """
     result = []
@@ -315,7 +319,7 @@ def get_wrapped_line_join(inpath, curline):
     """
     Reads the wrapped line and joins it into one.
 
-    Returns array of two strings: 
+    Returns array of two strings:
         1) the line content which will be further parsed
         2) comment with '\n' at the end
     If you join those strings you get exactly what was stored in the file
@@ -325,31 +329,31 @@ def get_wrapped_line_join(inpath, curline):
     comment = ''
     i = 0
     while i < len(wrapped):
-        l = wrapped[i]
+        wrapped_line = wrapped[i]
         if comment:
-            comment = comment + l
+            comment = comment + wrapped_line
         else:
-            if '//' in l:
-                l, comm = l.split('//', 1)
+            if '//' in wrapped_line:
+                wrapped_line, comm = wrapped_line.split('//', 1)
                 comment = '//' + comm
-                line = line + l
+                line = line + wrapped_line
             else:
-                line = line + l
+                line = line + wrapped_line
         i = i + 1
-    return [ line, comment ]
+    return [line, comment]
 
 
 def parse_begin_block(inpath, curline):
     beginDepth = 1
-    result = [ curline ]
+    result = [curline]
     while True:
         curline = inpath.readline()
         if not curline:
             raise ValueError("Reached EOF while looking for End")
-        l = curline.split()
+        line = curline.split()
         action = None
-        if len(l) > 0:
-            action = l[0].upper()
+        if len(line) > 0:
+            action = line[0].upper()
         if action == 'BEGIN':
             beginDepth = beginDepth + 1
         if action == 'END':
@@ -359,35 +363,37 @@ def parse_begin_block(inpath, curline):
             break
     return result
 
+
 def parse_mset_block(inpath, curline):
-    l = curline.split()
-    if len(l) < 2:
+    line = curline.split()
+    if len(line) < 2:
         raise ValueError("Use: MSET VARIABLE_NAME <lines> MsetEnd")
-    result = [ curline ]
+    result = [curline]
     while True:
         curline = inpath.readline()
         if not curline:
             raise ValueError("Reached EOF while looking for MSetEnd")
-        l = curline.split()
+        line = curline.split()
         action = None
-        if len(l) > 0:
-            action = l[0].upper()
+        if len(line) > 0:
+            action = line[0].upper()
         result.append(curline)
         if action in ("MSETEND", 'ENDMSET'):
             break
     return result
 
+
 def parse_if_block(inpath, curline):
     ifDepth = 1
-    result = [ curline ]
+    result = [curline]
     while True:
         curline = inpath.readline()
         if not curline:
             raise ValueError("Reached EOF while looking for EndIf")
-        l = curline.split()
+        line = curline.split()
         action = None
-        if len(l) > 0:
-            action = l[0].upper()
+        if len(line) > 0:
+            action = line[0].upper()
         if action == 'IF':
             ifDepth = ifDepth + 1
         if action in ('ENDIF', 'IFEND'):
@@ -397,38 +403,48 @@ def parse_if_block(inpath, curline):
             break
     return result
 
+
 def parse_supported_action(action, wline):
     line = []
-    if action == Glob.A_AUTHOR: # ['Author', ' Bob van der Poel\n']
+    if action == Glob.A_AUTHOR:
+        # ['Author', ' Bob van der Poel\n']
         line = tokenize_line(wline[0], 1)
-    elif action == Glob.A_DEF_GROOVE: # ['DefGroove', ' ', 'ModernJazz', '   ModernJazz with just a piano and guitar.\n']
+    elif action == Glob.A_DEF_GROOVE:
+        # ['DefGroove', ' ', 'ModernJazz', '   ModernJazz with just a piano and guitar.\n']
         line = tokenize_line(wline[0], 2)
-    elif action == Glob.A_GROOVE: # ['Groove', ' ', 'Tango', ' LightTango LightTangoSus LightTango\n']
+    elif action == Glob.A_GROOVE:
+        # ['Groove', ' ', 'Tango', ' LightTango LightTangoSus LightTango\n']
         line = tokenize_line(wline[0], 2)
-    elif action == Glob.A_REPEAT: # nothing to parse
-        line = [ wline[0] ]
-    elif action == Glob.A_REPEAT_END: # ['RepeatEnd', ' ', '2', '\n'] or ['RepeatEnd', '\n' ]
+    elif action == Glob.A_REPEAT:
+        # Nothing to parse
+        line = [wline[0]]
+    elif action == Glob.A_REPEAT_END:
+        # ['RepeatEnd', ' ', '2', '\n'] or ['RepeatEnd', '\n' ]
         line = tokenize_line(wline[0], 2)
-    elif action == Glob.A_REPEAT_ENDING: #
+    elif action == Glob.A_REPEAT_ENDING:
         line = tokenize_line(wline[0], 2)
-    elif action == Glob.A_TEMPO: # ['Tempo', ' ', '120', '\n']
+    elif action == Glob.A_TEMPO:
+        # ['Tempo', ' ', '120', '\n']
         line = tokenize_line(wline[0], 2)
-    elif action == Glob.A_TIME: # ['Time', ' ', '4'. '\n' ]
+    elif action == Glob.A_TIME:
+        # ['Time', ' ', '4'. '\n' ]
         line = tokenize_line(wline[0], 2)
     line.append(wline[1])
     return line
 
+
 def parse_supported_block_action(block_action, begin_block):
-    return [ begin_block[0], ''.join(begin_block[1:-1]), begin_block[-1] ]
+    return [begin_block[0], ''.join(begin_block[1:-1]), begin_block[-1]]
+
 
 def tokenize_line(line, limit):
     """
     Split the line into tokens and characters in between.
-    
+
     Example:
     ['Time', ' ', '4', '\n']
     ['Timesig', ' ', '4', ' ', '4', '\n']
-    ['DefGroove', ' ', 'ModernJazz', '    ModernJazz with just a piano and guitar.\n'] 
+    ['DefGroove', ' ', 'ModernJazz', '    ModernJazz with just a piano and guitar.\n']
     """
     chars_between = '\t\n\\ '
     tokenized_line = []
@@ -452,6 +468,7 @@ def tokenize_line(line, limit):
         read_token = not read_token
         start = end
     return tokenized_line
+
 
 """ =================================================================
 

--- a/src/main/python/linuxband/mma/parse.py
+++ b/src/main/python/linuxband/mma/parse.py
@@ -144,7 +144,7 @@ def parse(inpath):
 
         # track function BASS/DRUM/APEGGIO/CHORD ...
         if '-' in action:
-            trk_class, ext = action.split('-', 1)
+            trk_class = action.split('-', 1)[0]
         else:
             trk_class = action
 

--- a/src/main/python/linuxband/mma/song.py
+++ b/src/main/python/linuxband/mma/song.py
@@ -37,16 +37,21 @@ class Song(object):
     def load_from_file(self, file_name):
         logging.info("Loading file '%s'", file_name)
         try:
-            mma_file = file(file_name, 'r')
+            mma_file = open(file_name, 'r')
             try:
                 mma_data = mma_file.read()
+
             finally:
                 mma_file.close()
-        except IOError:
-            logging.exception("Unable to open '" + file_name + "' for input")
-            return -2
-        self.__pending_mma_data = mma_data
-        self.__song_data.set_save_needed(False)
+        
+        except IOError as e:
+            logging.exception("Unable to read '%s' for input:\n%s", file_name, e.strerror)
+        else:
+            self.__pending_mma_data = mma_data
+            self.__song_data.set_save_needed(False)
+        
+
+
 
     def load_from_string(self, mma_data):
         self.__pending_mma_data = mma_data
@@ -130,10 +135,11 @@ class Song(object):
     def __do_write_to_file(self, file_name, data):
         logging.info('Opening output file %s', file_name)
         try:
-            f = file(file_name, 'w')
+            f = open(file_name, 'w')
             try:
                 f.write(data)
             finally:
                 f.close()
-        except IOError:
-            logging.exception("Failed to save data to '" + file_name + "'.")
+        
+        except IOError as e:
+            logging.exception("Failed to save data to '%s':\n%s", file_name, e.strerror)

--- a/src/main/python/linuxband/mma/song_data.py
+++ b/src/main/python/linuxband/mma/song_data.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,9 +19,11 @@
 
 import copy
 import logging
+
+from linuxband.glob import Glob
 from linuxband.mma.bar_info import BarInfo
 from linuxband.mma.bar_chords import BarChords
-from linuxband.glob import Glob
+
 
 class SongData(object):
 
@@ -32,7 +36,7 @@ class SongData(object):
         self.__bar_info = bar_info
         self.__bar_chords = bar_chords
         self.__bar_count = bar_count
-        self.__beats_per_bar = 4 # TODO Beats/bar, set with TIME        
+        self.__beats_per_bar = 4  # TODO Beats/bar, set with TIME
         self.__save_needed = False
         for bar_info in self.__bar_info:
             bar_info.set_song_data(self)
@@ -74,7 +78,7 @@ class SongData(object):
         return self.__save_needed
 
     def changed(self):
-        logging.debug('Song changed');
+        logging.debug('Song changed')
         self.__save_needed = True
 
     def create_bar_info(self):
@@ -116,7 +120,7 @@ class SongData(object):
         if len(lines) > 0:
             if lines[0][0] == Glob.A_REMARK:
                 comm = lines[0][-1].strip()
-                comm = comm [2:] # remove '//'
+                comm = comm[2:]  # remove '//'
                 return comm.strip()
         return Glob.UNTITLED_SONG_NAME
 
@@ -124,7 +128,7 @@ class SongData(object):
         bar_info = self.__bar_info[0]
         # get first line
         lines = bar_info.get_lines()
-        if len(lines) == 0 or lines[0][0] <> Glob.A_REMARK:
+        if len(lines) == 0 or lines[0][0] != Glob.A_REMARK:
             line = [Glob.A_REMARK, ""]
             bar_info.insert_line(line)
         else:
@@ -143,7 +147,7 @@ class SongData(object):
     def write_to_string_with_midi_marks(self):
         """
         Write the mma file which will be compiled by mma and played in midi player.
-        
+
         We use macros to wrap chords. It allows the tracking of which bar is played.
         """
         mma_array = []
@@ -155,7 +159,7 @@ class SongData(object):
             mma_array.extend(self.__bar_chords[i].get_as_string_list())
             if i == self.__bar_count - 1:
                 mma_array.extend("MidiMark END\n")
-            mma_array.extend("MSetEnd\n") # 5 lines
+            mma_array.extend("MSetEnd\n")  # 5 lines
         # write the song
         for i in range(0, self.__bar_count):
             mma_array.extend(self.__bar_info[i].get_as_string_list())


### PR DESCRIPTION
Hi @noseka1,

I really like your project Linuxband and do want contribute at little to keep it alive.

This commit tries to make the code more [PEP8](https://www.python.org/dev/peps/pep-0008/) compliant by fixing most of
the reports generated by the [flake8](https://gitlab.com/pycqa/flake8) tool. Contrary to PEP8, I set the
maximum line length to a more reasonable value of 120 characters.

There are some whitespace reportings left, especially regarding the file
chord_table.py. However, this is intended to keep the chords tables
readable and totally consistent with [PEP20](https://www.python.org/dev/peps/pep-0020/) (The Zen of Python).

This work is preparing a possible port to Python 3 as Python 2 is close to [EOL.](https://pythonclock.org/)

The following changes have been made:

 - Cleanup unnecessary blank lines
 - Add blank lines where necessary
 - Use 'is' and  'is not' operator for comparisons to None
 - Split the use of multiple statements on one line (E701)
 - Remove semicola from statements (E703)
 - Remove unnecessary whitespaces (E201, E202)
 - Add whitespaces where necessary
 - Remove some useless inline comments
 - Replace '<>' with '!=' (W603)
 - Remove redundant backslash (E502)
 - Remove mixed indention with tabstops and whitespace
 - Sort module imports according to PEP8
 - Remove line break before binary operator (W503)
 - Fix ambigous variable naming (E741)
 - Fix usage of bare 'except' (E722)
 - Replace escape sequences with corresponding utf-8 symbol (W605)
 - Improve indention and alignment to increase readability
 - Fix wrong comment indention
 - Align line continuations with visual indent
 - Reduce length of some lines to keep em < 120 chars

Feedback is greatly appreciated.