### PR TITLE
Ignore some more automake/autoconf artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
+# Python byte code
 *.pyc
+
+# Automake artifacts
+autom4te.cache
 aclocal.m4
 config.h.in
 config.status
 configure
 install-sh
+
+# Configure artifacts 
 Makefile
+config.h
+config.log
+
+# Make artifacts
+target


### PR DESCRIPTION
I extended the gitignore file to cover some files that are generated by auto(re-)conf, automake and make. These are the autom4te.cache and target dirs, the config.h and config.log files. Just to keep the changelist clean, when building the project.