### PR TITLE
[PEP8] Add encoding info and fix blank lines.

### DIFF
--- a/src/main/python/linuxband.py.in
+++ b/src/main/python/linuxband.py.in
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -36,6 +38,7 @@ PKG_LIB_DIR = "@pkglibdir@"
 PYTHON_MAJOR = 2
 PYTHON_MINOR = 5
 
+
 def main():
     if not check_python_version():
         sys.exit(1)
@@ -62,9 +65,10 @@ def main():
     Glob.CONSOLE_LOG_LEVEL = console_log_level
     Logger.initLogging(console_log_level)
     logging.debug("%s %s" % (PACKAGE_NAME, PACKAGE_VERSION))
-	# start the gui
+    # start the gui
     from linuxband.gui.gui import Gui
     Gui()
+
 
 def check_python_version():
     if sys.version_info[0] != PYTHON_MAJOR or sys.version_info[1] < PYTHON_MINOR:
@@ -72,6 +76,7 @@ def check_python_version():
         print "Found Python version %s" % sys.version
         return False
     return True
+
 
 if __name__ == "__main__":
     main()

--- a/src/main/python/linuxband/__init__.py
+++ b/src/main/python/linuxband/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/config.py
+++ b/src/main/python/linuxband/config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/glob.py
+++ b/src/main/python/linuxband/glob.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -60,4 +62,3 @@ class Glob:
     LICENSE = ""
     PLAYER_PROGRAM = ""
     CONSOLE_LOG_LEVEL = None
-

--- a/src/main/python/linuxband/gui/__init__.py
+++ b/src/main/python/linuxband/gui/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/gui/about_dialog.py
+++ b/src/main/python/linuxband/gui/about_dialog.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/chord_sheet.py
+++ b/src/main/python/linuxband/gui/chord_sheet.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -564,4 +566,3 @@ class ChordSheet(object):
         pos = self.__song.get_data().get_beats_per_bar() * 2 * bar_y + bar_x * 2 + bar_chords
 
         return pos
-

--- a/src/main/python/linuxband/gui/common.py
+++ b/src/main/python/linuxband/gui/common.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -26,5 +28,3 @@ class Common(object):
         for name, member in inspect.getmembers(obj):
             dicts[name] = member
         glade.signal_autoconnect(dicts)
-
-

--- a/src/main/python/linuxband/gui/events/__init__.py
+++ b/src/main/python/linuxband/gui/events/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/events/repeat.py
+++ b/src/main/python/linuxband/gui/events/repeat.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,6 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 
 class EventRepeat(object):
 

--- a/src/main/python/linuxband/gui/events/repeat_end.py
+++ b/src/main/python/linuxband/gui/events/repeat_end.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/events/repeat_ending.py
+++ b/src/main/python/linuxband/gui/events/repeat_ending.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/events/tempo.py
+++ b/src/main/python/linuxband/gui/events/tempo.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/events_bar.py
+++ b/src/main/python/linuxband/gui/events_bar.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import gobject
 import gtk
+
 from linuxband.glob import Glob
 from linuxband.gui.common import Common
 from linuxband.gui.events.groove import EventGroove

--- a/src/main/python/linuxband/gui/gui.py
+++ b/src/main/python/linuxband/gui/gui.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -154,6 +156,7 @@ class Gui:
         self.__preferences.run()
 
     __ignore_toggle2 = False
+
     def switch_view_callback(self, item=None):
         if Gui.__ignore_toggle2:
             Gui.__ignore_toggle2 = False
@@ -186,7 +189,7 @@ class Gui:
     def change_song_bar_count(self, bar_count):
         """
         Set the count of song bars to bar_count.
-        
+
         Redraw affected fields
         Move cursor if it is necessary
         """
@@ -545,4 +548,3 @@ class Gui:
 
         self.__do_new_file()
         gtk.main()
-

--- a/src/main/python/linuxband/gui/gui_logger.py
+++ b/src/main/python/linuxband/gui/gui_logger.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/preferences.py
+++ b/src/main/python/linuxband/gui/preferences.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/save_button_status.py
+++ b/src/main/python/linuxband/gui/save_button_status.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/gui/source_editor.py
+++ b/src/main/python/linuxband/gui/source_editor.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/logger.py
+++ b/src/main/python/linuxband/logger.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import logging
 import sys
+
 
 class Logger(object):
 

--- a/src/main/python/linuxband/midi/__init__.py
+++ b/src/main/python/linuxband/midi/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/midi/midi_player.py
+++ b/src/main/python/linuxband/midi/midi_player.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/midi/mma2smf.py
+++ b/src/main/python/linuxband/midi/mma2smf.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/mma/__init__.py
+++ b/src/main/python/linuxband/mma/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -14,4 +16,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-

--- a/src/main/python/linuxband/mma/bar_chords.py
+++ b/src/main/python/linuxband/mma/bar_chords.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -63,9 +65,9 @@ class BarChords:
         return self.__eol
 
     def set_chord(self, beat_num, chord):
-        """ 
+        """
         Save one chord on given beat.
-        
+
         If chord == '' then actually delete the chord.
         """
         # [['Dm', ' '], ['/', ' '], ['AmzC@3.2', ' '], ['z!', '\n']]

--- a/src/main/python/linuxband/mma/bar_info.py
+++ b/src/main/python/linuxband/mma/bar_info.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -17,6 +19,7 @@
 
 import copy
 import logging
+
 from linuxband.glob import Glob
 
 

--- a/src/main/python/linuxband/mma/chord_table.py
+++ b/src/main/python/linuxband/mma/chord_table.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/mma/grooves.py
+++ b/src/main/python/linuxband/mma/grooves.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -80,9 +82,9 @@ class Grooves(object):
         return grooves_model
 
     def __load_grooves(self):
-        """ 
+        """
         Load grooves from /usr/share/mma/lib/stdlib (configurable).
-        
+
         Sort grooves and store them in grooves_list
         Call __create_grooves_model()
         """

--- a/src/main/python/linuxband/mma/parse.py
+++ b/src/main/python/linuxband/mma/parse.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -34,6 +36,7 @@ from linuxband.mma.song_data import SongData
 ########################################
 # File processing. Mostly jumps to pats
 ########################################
+
 
 def parse(inpath):
     """
@@ -226,7 +229,7 @@ def parse(inpath):
                         NOTE: lyric.extract() inserts previously created
                         data from LYRICS SET and inserts the chord names
                         if that flag is active.
-        
+
                     """
                     lyrics_count += 1
                 elif ch == '}':
@@ -296,7 +299,7 @@ def parse(inpath):
 def get_wrapped_line(inpath, curline):
     """
     Reads the whole wrapped line ('\' at the end) and stores it in a list.
-    
+
     The lines in the list are not modified and are the same as in the file
     """
     result = []
@@ -452,6 +455,7 @@ def tokenize_line(line, limit):
         read_token = not read_token
         start = end
     return tokenized_line
+
 
 """ =================================================================
 

--- a/src/main/python/linuxband/mma/song.py
+++ b/src/main/python/linuxband/mma/song.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.

--- a/src/main/python/linuxband/mma/song_data.py
+++ b/src/main/python/linuxband/mma/song_data.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2012 Ales Nosek <ales.nosek@gmail.com>
 #
 # This file is part of LinuxBand.
@@ -143,7 +145,7 @@ class SongData(object):
     def write_to_string_with_midi_marks(self):
         """
         Write the mma file which will be compiled by mma and played in midi player.
-        
+
         We use macros to wrap chords. It allows the tracking of which bar is played.
         """
         mma_array = []


### PR DESCRIPTION
This is the first part of a series of changes to make the Python code more PEP8 compliant. I currently use flake8 to inspect the code.

This commit add a text encoding info as this first line of each Python
file. Furthermore, it adds some blank lines required by PEP8 and removes
some trailing blank lines and whitespaces inside some doc strings and at the end of some files.