### PR TITLE
[PEP8] Improve import ordering

### DIFF
--- a/src/main/python/linuxband.py.in
+++ b/src/main/python/linuxband.py.in
@@ -18,11 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import logging
-import pygtk
-pygtk.require("2.0")
+import sys
+
 import gobject
+import pygtk
+
+pygtk.require("2.0")
+
 
 # substituted by autoconf
 PACKAGE_NAME = "@PACKAGE_NAME@"

--- a/src/main/python/linuxband/config.py
+++ b/src/main/python/linuxband/config.py
@@ -19,8 +19,9 @@
 
 import ConfigParser
 import logging
-from linuxband.glob import Glob
 import os
+
+from linuxband.glob import Glob
 
 
 class Config(object):

--- a/src/main/python/linuxband/gui/about_dialog.py
+++ b/src/main/python/linuxband/gui/about_dialog.py
@@ -18,8 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from linuxband.gui.common import Common
+
 from linuxband.glob import Glob
+from linuxband.gui.common import Common
 
 
 class AboutDialog(object):

--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -17,9 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
 import gobject
+import gtk
+
 from gtk.gdk import CONTROL_MASK
+
 from linuxband.gui.common import Common
 from linuxband.mma.chord_table import chordlist
 

--- a/src/main/python/linuxband/gui/chord_sheet.py
+++ b/src/main/python/linuxband/gui/chord_sheet.py
@@ -17,14 +17,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import copy
+import logging
+
 import gtk
 import pango
-import copy
+
 from gtk.gdk import CONTROL_MASK, SHIFT_MASK, BUTTON1_MASK
-import logging
+
+from linuxband.gui.common import Common
 from linuxband.mma.bar_chords import BarChords
 from linuxband.mma.bar_info import BarInfo
-from linuxband.gui.common import Common
 
 
 class ChordSheet(object):

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -17,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import gobject
 import gtk
 import pango
-import gobject
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventGroove(object):

--- a/src/main/python/linuxband/gui/events/repeat_end.py
+++ b/src/main/python/linuxband/gui/events/repeat_end.py
@@ -18,9 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventRepeatEnd(object):

--- a/src/main/python/linuxband/gui/events/repeat_ending.py
+++ b/src/main/python/linuxband/gui/events/repeat_ending.py
@@ -18,9 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventRepeatEnding(object):

--- a/src/main/python/linuxband/gui/events/tempo.py
+++ b/src/main/python/linuxband/gui/events/tempo.py
@@ -18,8 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from linuxband.glob import Glob
-from linuxband.mma.bar_info import BarInfo
 from linuxband.gui.common import Common
+from linuxband.mma.bar_info import BarInfo
 
 
 class EventTempo(object):

--- a/src/main/python/linuxband/gui/gui.py
+++ b/src/main/python/linuxband/gui/gui.py
@@ -17,25 +17,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import pango
 import logging
-import gtk.glade
+
 import gobject
-from linuxband.glob import Glob
-from linuxband.gui.gui_logger import GuiLogger
+import gtk.glade
+import pango
+
 from linuxband.config import Config
-from linuxband.midi.midi_player import MidiPlayer
-from linuxband.gui.chord_sheet import ChordSheet
-from linuxband.gui.source_editor import SourceEditor
+from linuxband.glob import Glob
+from linuxband.gui.about_dialog import AboutDialog
 from linuxband.gui.chord_entries import ChordEntries
-from linuxband.gui.events_bar import EventsBar
+from linuxband.gui.chord_sheet import ChordSheet
 from linuxband.gui.common import Common
+from linuxband.gui.gui_logger import GuiLogger
+from linuxband.gui.events_bar import EventsBar
+from linuxband.gui.save_button_status import SaveButtonStatus
+from linuxband.gui.source_editor import SourceEditor
+from linuxband.gui.preferences import Preferences
+from linuxband.midi.midi_player import MidiPlayer
+from linuxband.midi.mma2smf import MidiGenerator
 from linuxband.mma.song import Song
 from linuxband.mma.grooves import Grooves
-from linuxband.gui.about_dialog import AboutDialog
-from linuxband.midi.mma2smf import MidiGenerator
-from linuxband.gui.preferences import Preferences
-from linuxband.gui.save_button_status import SaveButtonStatus
 
 
 class Gui:

--- a/src/main/python/linuxband/gui/preferences.py
+++ b/src/main/python/linuxband/gui/preferences.py
@@ -17,8 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from linuxband.gui.common import Common
 import gtk
+
+from linuxband.gui.common import Common
+
 
 class Preferences(object):
 

--- a/src/main/python/linuxband/gui/source_editor.py
+++ b/src/main/python/linuxband/gui/source_editor.py
@@ -17,11 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 import gobject
 import gtk
 import gtksourceview2
 import pango
-import logging
+
 from linuxband.glob import Glob
 
 

--- a/src/main/python/linuxband/midi/midi_player.py
+++ b/src/main/python/linuxband/midi/midi_player.py
@@ -17,14 +17,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import threading
-import os
 import fcntl
+import logging
+import os
 import select
 import subprocess
+import threading
+
 import gobject
-import logging
+
 from linuxband.glob import Glob
+
 
 class MidiPlayer:
 

--- a/src/main/python/linuxband/midi/mma2smf.py
+++ b/src/main/python/linuxband/midi/mma2smf.py
@@ -17,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import os
 import select
-import subprocess
 import string
+import subprocess
+
 from linuxband.glob import Glob
-import logging
 
 
 class MidiGenerator(object):

--- a/src/main/python/linuxband/mma/grooves.py
+++ b/src/main/python/linuxband/mma/grooves.py
@@ -17,14 +17,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import pickle
-import logging
 import fnmatch
+import logging
 import os
+import pickle
+
+import gtk
+
 from linuxband.glob import Glob
-from linuxband.mma.parse import parse
 from linuxband.mma.bar_info import BarInfo
+from linuxband.mma.parse import parse
 
 
 class Grooves(object):

--- a/src/main/python/linuxband/mma/song.py
+++ b/src/main/python/linuxband/mma/song.py
@@ -19,9 +19,11 @@
 
 import cStringIO
 import logging
+
+from linuxband.mma.bar_info import BarInfo
 from linuxband.mma.parse import parse
 from linuxband.mma.song_data import SongData
-from linuxband.mma.bar_info import BarInfo
+
 
 class Song(object):
 

--- a/src/main/python/linuxband/mma/song_data.py
+++ b/src/main/python/linuxband/mma/song_data.py
@@ -19,9 +19,11 @@
 
 import copy
 import logging
+
+from linuxband.glob import Glob
 from linuxband.mma.bar_info import BarInfo
 from linuxband.mma.bar_chords import BarChords
-from linuxband.glob import Glob
+
 
 class SongData(object):
 


### PR DESCRIPTION
This commit groups the imports into standard library imports, related
third-party imports and local application specific imports as suggested
by PEP8 and sorts each group alphabetically.