### PR TITLE
[PEP8] Cleanup white space, comments and semicola

### DIFF
--- a/src/main/python/linuxband/glob.py
+++ b/src/main/python/linuxband/glob.py
@@ -28,7 +28,7 @@ class Glob:
     A_DEF_GROOVE = "DEFGROOVE"
     A_DOC = "DOC"
     A_GROOVE = "GROOVE"
-    A_REMARK = "REMARK" # comment line with song title
+    A_REMARK = "REMARK"  # comment line with song title
     A_REPEAT = "REPEAT"
     A_REPEAT_END = "REPEATEND"
     A_REPEAT_ENDING = "REPEATENDING"
@@ -38,12 +38,12 @@ class Glob:
     A_UNKNOWN = "UNKNOWN"
 
     # list of supported events, order of Add event menulist
-    EVENTS = [ A_GROOVE, A_TEMPO, A_REPEAT, A_REPEAT_ENDING, A_REPEAT_END ]
+    EVENTS = [A_GROOVE, A_TEMPO, A_REPEAT, A_REPEAT_ENDING, A_REPEAT_END]
 
     OUTPUT_FILE_DEFAULT = "untitled.mma"
     UNTITLED_SONG_NAME = "Untitled Song"
 
-        # user's home dir - works for windows/unix/linux
+    # user's home dir - works for windows/unix/linux
     HOME_DIR = os.getenv('USERPROFILE') or os.getenv('HOME')
     CONFIG_DIR = HOME_DIR + '/.linuxband'
 

--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -46,7 +46,7 @@ class ChordEntries(object):
             chords = self.__song.get_data().get_bar_chords(barnum).get_chords()
             for i in range(len(chords)):
                 chord = chords[i][0]
-                if chord == '/': # don't show '/' as chord
+                if chord == '/':  # don't show '/' as chord
                     self.__entries[i].set_text('')
                 else:
                     self.__entries[i].set_text(chord)
@@ -159,7 +159,7 @@ class ChordEntries(object):
         
         It is used for entry completion
         """
-        base = [ 'C', 'D', 'E', 'F', 'G', 'A', 'B' ]
+        base = ['C', 'D', 'E', 'F', 'G', 'A', 'B']
         base_ext = []
         for c in base:
             base_ext.append(c)

--- a/src/main/python/linuxband/gui/chord_sheet.py
+++ b/src/main/python/linuxband/gui/chord_sheet.py
@@ -60,7 +60,7 @@ class ChordSheet(object):
         self.drawable = self.__area.window
         self.gc = self.drawable.new_gc()
         # Create a new backing pixmap of the appropriate size
-        self.pixmap = gtk.gdk.Pixmap(self.drawable, self.__drawing_area_width, self.__drawing_area_height, depth= -1)
+        self.pixmap = gtk.gdk.Pixmap(self.drawable, self.__drawing_area_width, self.__drawing_area_height, depth=-1)
         gc = self.drawable.new_gc()
         gc.copy(self.gc)
         green = self.__colormap.alloc_color(ChordSheet.__color_no_song, True, True)
@@ -70,7 +70,7 @@ class ChordSheet(object):
 
     def drawing_area_expose_event_callback(self, widget, event):
         """ Redraw the screen from the backing pixmap. """
-        x , y, width, height = event.area
+        x, y, width, height = event.area
         widget.window.draw_drawable(widget.get_style().fg_gc[gtk.STATE_NORMAL],
         self.pixmap, x, y, x, y, width, height)
         return True
@@ -78,7 +78,7 @@ class ChordSheet(object):
     def move_playhead_to(self, pos):
         new_pos = pos * 2 + 1 if pos > -1 else -1
         old_pos = self.__playhead_pos
-        if  old_pos != new_pos:
+        if old_pos != new_pos:
             self.__playhead_pos = new_pos
             self.__render_field(old_pos)
             self.__render_field(new_pos)
@@ -116,15 +116,15 @@ class ChordSheet(object):
                 self.__move_cursor_to(self.__cursor_pos + 2)
                 self.__destroy_selection()
         # adjust selection
-        if key in [ gtk.keysyms.Left, gtk.keysyms.Right, gtk.keysyms.Up, gtk.keysyms.Down,
-                         gtk.keysyms.Home, gtk.keysyms.End ]:
+        if key in [gtk.keysyms.Left, gtk.keysyms.Right, gtk.keysyms.Up,
+                   gtk.keysyms.Down, gtk.keysyms.Home, gtk.keysyms.End]:
             if event.state & SHIFT_MASK:
                 self.__adjust_selection(old_pos)
             else:
                 self.__destroy_selection()
-        if key in [ gtk.keysyms.H, gtk.keysyms.L, gtk.keysyms.K, gtk.keysyms.J ]:
+        if key in [gtk.keysyms.H, gtk.keysyms.L, gtk.keysyms.K, gtk.keysyms.J]:
             self.__adjust_selection(old_pos)
-        if key in [ gtk.keysyms.h, gtk.keysyms.l, gtk.keysyms.k, gtk.keysyms.j ]:
+        if key in [gtk.keysyms.h, gtk.keysyms.l, gtk.keysyms.k, gtk.keysyms.j]:
             self.__destroy_selection()
         # the event has been handled
         return True
@@ -162,7 +162,7 @@ class ChordSheet(object):
             self.__destroy_selection()
             old_pos = self.__cursor_pos
             new_pos = old_pos + length - 1
-            self.__move_cursor_to(new_pos) # if needed new fields will be appended
+            self.__move_cursor_to(new_pos)  # if needed new fields will be appended
             bar_num = old_pos / 2
             for field in clipboard:
                 if isinstance(field, BarChords):
@@ -243,7 +243,7 @@ class ChordSheet(object):
         new_end = bar_count * 2
         if new_end == self.__end_position:
             return
-        elif new_end > self.__end_position: # render affected fields
+        elif new_end > self.__end_position:  # render affected fields
             fields_to_render = range(self.__end_position, new_end + 1)
             for field in fields_to_render: self.__render_field(field)
         elif new_end < self.__end_position:
@@ -284,7 +284,7 @@ class ChordSheet(object):
         return self.__cursor_pos / 2
 
     def new_song_loaded(self):
-        self.__move_cursor_to(0) # cursor on field 0 => global buttons get refreshed
+        self.__move_cursor_to(0)  # cursor on field 0 => global buttons get refreshed
         self.__destroy_selection()
 
     def render_current_field(self, chords=None):
@@ -311,9 +311,9 @@ class ChordSheet(object):
         else: color = self.__colormap.alloc_color('black')
         gc = self.pixmap.new_gc()
         gc.copy(self.gc)
-        #gc.set_line_attributes(1, gtk.gdk.LINE_SOLID, gtk.gdk.CAP_ROUND, gtk.gdk.JOIN_ROUND)
+        # gc.set_line_attributes(1, gtk.gdk.LINE_SOLID, gtk.gdk.CAP_ROUND, gtk.gdk.JOIN_ROUND)
         gc.set_foreground(color)
-        #self.pixmap.draw_rectangle(gc, False, x , y, width, height)
+        # self.pixmap.draw_rectangle(gc, False, x , y, width, height)
 
         pango_layout = self.__area.create_pango_layout("")
         pango_layout.set_text(chord)
@@ -423,8 +423,8 @@ class ChordSheet(object):
         gc = self.drawable.new_gc()
         gc.copy(self.gc)
         gc.set_foreground(color)
-        self.pixmap.draw_rectangle(gc, True, x , y, self.__bar_info_width, ChordSheet.__bar_height)
-        if cursor: # black border
+        self.pixmap.draw_rectangle(gc, True, x, y, self.__bar_info_width, ChordSheet.__bar_height)
+        if cursor:  # black border
             color = self.__colormap.alloc_color('black')
             gc.set_foreground(color)
             self.pixmap.draw_rectangle(gc, False, x, y, self.__bar_info_width - 1, ChordSheet.__bar_height - 1)
@@ -437,7 +437,7 @@ class ChordSheet(object):
             if repeat_begin: self.__draw_repetition(x, y, gc, False)
             if repeat_end: self.__draw_repetition(x, y, gc, True)
         else:
-            if bar_num < self.__song.get_data().get_bar_count() and chord_num: # draw bar number
+            if bar_num < self.__song.get_data().get_bar_count() and chord_num:  # draw bar number
                 pango_layout = self.__area.create_pango_layout("")
                 pango_layout.set_text(str(chord_num))
                 fd = pango.FontDescription('Monospace Bold 8')

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -88,9 +88,9 @@ class EventGroove(object):
         colormap = groove_window.get_colormap()
         color = colormap.alloc_color('red')
         self.__textbuffer2.create_tag('fg_red', foreground_gdk=color)
-        color = colormap.alloc_color('brown');
+        color = colormap.alloc_color('brown')
         self.__textbuffer2.create_tag('fg_brown', foreground_gdk=color)
-        color = colormap.alloc_color('black');
+        color = colormap.alloc_color('black')
         self.__textbuffer2.create_tag('fg_black', foreground_gdk=color)
         self.__textbuffer2.create_tag("bold", weight=pango.WEIGHT_BOLD)
         self.__togglebutton1 = glade.get_widget("togglebutton1")

--- a/src/main/python/linuxband/gui/events_bar.py
+++ b/src/main/python/linuxband/gui/events_bar.py
@@ -85,9 +85,9 @@ class EventsBar(object):
         self.__remove_from_triples(self.__toggled_triple[0])
         # remove button and close the window
         self.__hbox8.remove(self.__toggled_triple[0])
-        self.__toggle_window_close() # deletes the self.__toggled_triple
+        self.__toggle_window_close()  # deletes the self.__toggled_triple
         self.__refresh_globals()
-        self.__gui.refresh_current_field() # repetition
+        self.__gui.refresh_current_field()  # repetition
 
     def add_event_clicked_callback(self, button):
         """ Add event button pressed. """
@@ -144,7 +144,7 @@ class EventsBar(object):
             else:
                 barNum = self.__gui.get_current_bar_number()
                 self.__song.get_data().get_bar_info(barNum).replace_event(self.__curr_event, newEvent)
-            self.refresh_all() # global groove or global tempo could have been changed
+            self.refresh_all()  # global groove or global tempo could have been changed
 
     def main_window_configure_event_callback(self, widget, event):
         """ Everytime the main window is moved or resised, move the toggle window with it. """
@@ -195,8 +195,8 @@ class EventsBar(object):
         # global buttons
         self.__eventGroove = EventGroove(glade, self.__grooves)
         self.__eventTempo = EventTempo(glade)
-        self.__triples.append([ self.__togglebutton1, groove_window, self.__eventGroove, None ])
-        self.__triples.append([ self.__togglebutton2, tempo_window, self.__eventTempo, None ])
+        self.__triples.append([self.__togglebutton1, groove_window, self.__eventGroove, None])
+        self.__triples.append([self.__togglebutton2, tempo_window, self.__eventTempo, None])
         # add event menu
         event_items = { Glob.A_GROOVE: "Groove change",
                       Glob.A_TEMPO: "Tempo change",
@@ -252,7 +252,7 @@ class EventsBar(object):
         event = BarInfo.create_event(key)
         self.__song.get_data().get_bar_info(barNum).add_event(event)
         self.refresh_all()
-        self.__gui.refresh_current_field() # repetition
+        self.__gui.refresh_current_field()  # repetition
         # open the new event window
         for triple in self.__triples:
             if triple[3] is event:
@@ -268,7 +268,7 @@ class EventsBar(object):
     def __move_window_underneath(self, gtkwindow, widget):
         """ Move window to appear directly under the toggled button """
         rect = widget.get_allocation()
-        rect2 = self.__main_window.get_allocation() # (0, 0, 1100, 700)
+        rect2 = self.__main_window.get_allocation()  # (0, 0, 1100, 700)
 
         # black magic to get the correct values into rect3 
         gtkwindow.realize()
@@ -277,8 +277,8 @@ class EventsBar(object):
         rect3 = gtkwindow.get_allocation()
 
         # this has a side effect that x, y on the following line are set properly
-        x1, y1 = self.__main_window.window.get_root_origin() # decoration window  @UnusedVariable
-        x, y = self.__main_window.window.get_origin() # our window
+        x1, y1 = self.__main_window.window.get_root_origin()  # decoration window  @UnusedVariable
+        x, y = self.__main_window.window.get_origin()  # our window
 
         wx = min(x + rect.x, x + rect2.width - rect3.width)
         wy = y + rect.y + rect.height
@@ -286,9 +286,9 @@ class EventsBar(object):
         gtkwindow.move(wx, wy)
 
     def __get_widget_xy_position(self, widget, gtkwindow):
-        #""" Move window to appear directly under the toggle button """
+        # Move window to appear directly under the toggle button
         rect = widget.get_allocation()
-        rect2 = self.__main_window.get_allocation() # (0, 0, 1100, 700)
+        rect2 = self.__main_window.get_allocation()  # (0, 0, 1100, 700)
 
         # black magic to get the correct values into rect3 
         gtkwindow.realize()
@@ -297,11 +297,11 @@ class EventsBar(object):
         rect3 = gtkwindow.get_allocation()
 
         # this has a side effect that x, y on the following line are set properly
-        x1, y1 = self.__main_window.window.get_root_origin() # decoration window  @UnusedVariable
-        x, y = self.__main_window.window.get_origin() # our window
+        x1, y1 = self.__main_window.window.get_root_origin()  # decoration window  @UnusedVariable
+        x, y = self.__main_window.window.get_origin()  # our window
 
         wx = min(x + rect.x, x + rect2.width - rect3.width)
-        wy = y + rect.y #+ rect.height
+        wy = y + rect.y
 
         return (wx, wy)
 

--- a/src/main/python/linuxband/gui/gui.py
+++ b/src/main/python/linuxband/gui/gui.py
@@ -101,7 +101,7 @@ class Gui:
             if self.__chord_sheet.has_focus() and self.__chord_sheet.is_cursor_on_bar_chords():
                 self.__chord_entries.begin_writing(keyname)
                 return True
-        elif keyname == 'e' and self.__chord_sheet.has_focus(): # TODO: doesn't work
+        elif keyname == 'e' and self.__chord_sheet.has_focus():  # TODO: doesn't work
             self.__events_bar.grab_focus()
             return True
         elif (self.__chord_sheet.has_focus() or self.__notebook3.has_focus()) and keyname == 'space':
@@ -280,7 +280,7 @@ class Gui:
                 player.load_smf_data(midi_data, self.__song.get_data().get_mma_line_offset())
             else:
                 return
-            self.__enable_pause_button();
+            self.__enable_pause_button()
             if event.state & gtk.gdk.CONTROL_MASK:
                 player.playback_start_bar(self.__chord_sheet.get_current_bar_number())
             elif event.state & gtk.gdk.SHIFT_MASK:
@@ -290,25 +290,26 @@ class Gui:
 
     def playback_stop_callback(self, button=None):
         """ Stop. """
-        self.__enable_pause_button();
+        self.__enable_pause_button()
         self.__midi_player.playback_stop()
 
     __ignore_toggle = False
+
     def playback_pause_callback(self, button=None):
         """ Pause. """
         if Gui.__ignore_toggle:
             Gui.__ignore_toggle = False
         else:
-            self.__midi_player.set_pause(button.get_active());
+            self.__midi_player.set_pause(button.get_active())
 
     def jack_reconnect_callback(self, button):
         self.__midi_player.shutdown()
-        self.__midi_player.startup();
+        self.__midi_player.startup()
 
     def switch_page_callback(self, notebook, page, pageNum):
         """ Called when clicked on notebook tab. """
         logging.debug("")
-        if pageNum == 1: # switching to source editor
+        if pageNum == 1:  # switching to source editor
             self.__source_editor.refresh_source(self.__song.write_to_string())
             self.__source_editor.grab_focus()
             self.__notebook2.set_current_page(pageNum)
@@ -317,7 +318,7 @@ class Gui:
                 Gui.__ignore_toggle2 = True
                 self.__menuitem7.set_active(True)
             self.__global_buttons.hide()
-        else: # switching to chord sheet
+        else:  # switching to chord sheet
             res = self.__compile_song(True)
             if res > 0 or res == -1:
                 logging.error("Cannot switch to chord sheet view. Fix the errors and try again.")
@@ -334,7 +335,7 @@ class Gui:
 
     def loop_toggle_callback(self, button):
         """ Loop check button. """
-        self.__midi_player.set_loop(button.get_active());
+        self.__midi_player.set_loop(button.get_active())
         self.__config.set_loop(button.get_active())
 
     def jack_transport_toggle_callback(self, button):
@@ -486,7 +487,7 @@ class Gui:
         Common.connect_signals(glade, self)
 
         self.__main_window = glade.get_widget("mainWindow")
-        self.__spinbutton1 = glade.get_widget("spinbutton1") # bar count 
+        self.__spinbutton1 = glade.get_widget("spinbutton1")  # bar count
         self.__notebook2 = glade.get_widget("notebook2")
         self.__notebook3 = glade.get_widget("notebook3")
 

--- a/src/main/python/linuxband/gui/gui_logger.py
+++ b/src/main/python/linuxband/gui/gui_logger.py
@@ -31,13 +31,13 @@ class GuiLogger(object):
             self.__textBuffer = textBuffer
 
         def emit(self, record):
-            record.exc_text = None # is needed to formatException to be called
+            record.exc_text = None  # is needed to formatException to be called
 
             if record.levelname == 'INFO': tag = 'fg_black'
             elif record.levelname == 'WARNING': tag = 'fg_brown'
             elif record.levelname == 'ERROR': tag = 'fg_red'
 
-            start, end = self.__textBuffer.get_bounds() #@UnusedVariable
+            start, end = self.__textBuffer.get_bounds()
             text = self.__textBuffer.get_text(start, end)
             eol = '' if text == '' else '\n'
 
@@ -70,9 +70,9 @@ class GuiLogger(object):
         colormap = textView.get_colormap()
         color = colormap.alloc_color('red')
         textBuffer.create_tag('fg_red', foreground_gdk=color)
-        color = colormap.alloc_color('brown');
+        color = colormap.alloc_color('brown')
         textBuffer.create_tag('fg_brown', foreground_gdk=color)
-        color = colormap.alloc_color('black');
+        color = colormap.alloc_color('black')
         textBuffer.create_tag('fg_black', foreground_gdk=color)
 
     @staticmethod
@@ -82,5 +82,5 @@ class GuiLogger(object):
         textBufferHandler = GuiLogger.__TextBufferHandler(textView, textBuffer)
         textBufferHandler.setLevel(logging.INFO)
         textBufferHandler.setFormatter(GuiLogger.__MyFormatter(guiFormat, dateFormat))
-        rootLogger = logging.getLogger();
+        rootLogger = logging.getLogger()
         rootLogger.addHandler(textBufferHandler)

--- a/src/main/python/linuxband/gui/preferences.py
+++ b/src/main/python/linuxband/gui/preferences.py
@@ -31,7 +31,7 @@ class Preferences(object):
         self.__init_gui(glade)
 
     def run(self):
-        self.__initWidgets();
+        self.__initWidgets()
         result = self.__preferencesdialog.run()
         self.__preferencesdialog.hide()
         if (result == gtk.RESPONSE_OK):

--- a/src/main/python/linuxband/gui/save_button_status.py
+++ b/src/main/python/linuxband/gui/save_button_status.py
@@ -32,6 +32,6 @@ class SaveButtonStatus(object):
         save_needed = song.get_data().is_save_needed()
         button.set_sensitive(save_needed)
         menuitem.set_sensitive(save_needed)
-        prefix = "*"  if save_needed else ""
+        prefix = "*" if save_needed else ""
         mainwindow.set_title(prefix + song.get_data().get_title() + " | Linux Band")
         return True

--- a/src/main/python/linuxband/gui/source_editor.py
+++ b/src/main/python/linuxband/gui/source_editor.py
@@ -64,7 +64,7 @@ class SourceEditor(object):
             iter1 = buff.get_iter_at_line(line)
             iter2 = buff.get_iter_at_line(line + 1)
             buff.apply_tag_by_name("error", iter1, iter2)
-            # error marker    
+            # error marker
             it = buff.get_iter_at_line(line)
             buff.create_source_mark(None, self.ERROR_MARKER, it)
         self.__error_mark_pos = line

--- a/src/main/python/linuxband/midi/midi_player.py
+++ b/src/main/python/linuxband/midi/midi_player.py
@@ -76,9 +76,10 @@ class MidiPlayer:
         self.__pipew = pipew
 
         pipeName = '/proc/' + str(Glob.PID) + '/fd/' + str(pipew)
-        command = [ Glob.PLAYER_PROGRAM, '-s', '-n', '-x', pipeName ]
+        command = [Glob.PLAYER_PROGRAM, '-s', '-n', '-x', pipeName]
         if Glob.CONSOLE_LOG_LEVEL == logging.DEBUG:
             command.insert(1, '-d')
+        
         try:
             self.__player = subprocess.Popen(command, stdin=subprocess.PIPE)
         except:
@@ -86,12 +87,14 @@ class MidiPlayer:
             os.close(piper)
             os.close(pipew)
             return
-        # sending data to midi player should not block    
+
+            # Sending data to midi player should not block
         out = self.__player.stdin.fileno()
         flags = fcntl.fcntl(out, fcntl.F_GETFL)
         fcntl.fcntl(out, fcntl.F_SETFL, flags | os.O_NONBLOCK)
         self.__pout = out
-        # start receive thread listening for incoming events
+
+            # Start receive thread listening for incoming events
         self.__receive_thread = threading.Thread(target=self.__receive_data)
         self.__receive_thread.start()
         self.__connected = True
@@ -102,12 +105,14 @@ class MidiPlayer:
             os.write(self.__pipew, MidiPlayer.__COMM_FINISH + MidiPlayer.__SEPARATOR)
             self.__receive_thread.join()
             self.__receive_thread = None
+        
         if self.__player:
             self.playback_stop()
             self.__send_token(MidiPlayer.__COMM_FINISH)
             self.__player.wait()
             self.__player = None
-        # descriptors could have been already closed
+        
+        # Descriptors could have been already closed
         try:
             os.close(self.__piper)
         except:

--- a/src/main/python/linuxband/midi/mma2smf.py
+++ b/src/main/python/linuxband/midi/mma2smf.py
@@ -36,7 +36,7 @@ class MidiGenerator(object):
         < -1 other error, = -1 MMA error unknown line, 0 is OK, > 0 MMA error line
         """
         mmainput = '/proc/self/fd/0'
-        command = [ self.__config.get_mma_path(), mmainput, '-n' ] # -n No generation of midi output
+        command = [self.__config.get_mma_path(), mmainput, '-n']  # -n No generation of midi output
         try:
             mma = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         except:
@@ -82,7 +82,8 @@ class MidiGenerator(object):
         """
         mmainput = '/proc/self/fd/0'
         mmaoutput = '/proc/' + str(Glob.PID) + '/fd/' + str(pipew)
-        command = [ self.__config.get_mma_path(), mmainput, '-f' , mmaoutput ]
+        command = [self.__config.get_mma_path(), mmainput, '-f', mmaoutput]
+        
         try:
             mma = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         except:

--- a/src/main/python/linuxband/mma/bar_chords.py
+++ b/src/main/python/linuxband/mma/bar_chords.py
@@ -28,7 +28,7 @@ class BarChords:
         self.__before_number = ''
         self.__number = None
         self.__after_number = ' '
-        self.__chords = [[ '/', '' ]] # one chord is always there
+        self.__chords = [['/', '']]  # one chord is always there
         self.__eol = '\n'
 
     def set_song_data(self, song_data):
@@ -75,31 +75,31 @@ class BarChords:
         song_data = self.__song_data
         if chord == '' and beat_num >= len(self.__chords):
             return
-        if beat_num + 1 < len(chords): # there's a chord after this beat
+        if beat_num + 1 < len(chords):  # there's a chord after this beat
             full_chord = chords[beat_num]
             if not chord: chord = '/'
             if full_chord[0] != chord:
                 full_chord[0] = chord
                 song_data.changed()
         else:
-            if not chord: # delete a chord
+            if not chord:  # delete a chord
                 full_chord = chords[beat_num]
-                if beat_num > 0: # there is some chord before us
+                if beat_num > 0:  # there is some chord before us
                     # possibly move trailing string from our chord to eol
                     self.__eol = ''.join(full_chord[1:]) + self.__eol
                     chords.pop(beat_num)
                     song_data.changed()
-                else: # the only chord on the line
+                else:  # the only chord on the line
                     if full_chord[0] != '/':
                         full_chord[0] = '/'
                         song_data.changed()
-            else: # add or replace chord
-                if beat_num < len(chords): # replace an existing chord
+            else:  # add or replace chord
+                if beat_num < len(chords):  # replace an existing chord
                     full_chord = chords[beat_num]
                     if full_chord[0] != chord:
                         full_chord[0] = chord
                         song_data.changed()
-                else: # append a chord
+                else:  # append a chord
                     last_full_chord = chords[len(chords) - 1]
                     if len(last_full_chord[1]) == len(last_full_chord[1].rstrip()):
                         last_full_chord[1] = last_full_chord[1] + ' '

--- a/src/main/python/linuxband/mma/bar_info.py
+++ b/src/main/python/linuxband/mma/bar_info.py
@@ -71,7 +71,7 @@ class BarInfo:
         return self.__lines
 
     def add_event(self, line):
-        if line[0] in [ Glob.A_REPEAT_END, Glob.A_REPEAT_ENDING ]:
+        if line[0] in [Glob.A_REPEAT_END, Glob.A_REPEAT_ENDING]:
             self.insert_line(line)
         else:
             self.add_line(line)
@@ -166,13 +166,13 @@ class BarInfo:
     @staticmethod
     def set_repeat_end_value(line, count):
         # example line: ['REPEATEND', 'RepeatEnd', ' ', '2', '\n']
-        if len(line) > 3: # there is already some number
+        if len(line) > 3:  # there is already some number
             if count == 2:
                 line.pop(2)
                 line.pop(2)
             else:
                 line[3] = count
-        else: # no number yet, example: ['REPEATEND', 'RepeatEnd', '\n']
+        else:  # no number yet, example: ['REPEATEND', 'RepeatEnd', '\n']
             if count != 2:
                 line.insert(2, count)
                 line.insert(2, ' ')

--- a/src/main/python/linuxband/mma/chord_table.py
+++ b/src/main/python/linuxband/mma/chord_table.py
@@ -450,11 +450,10 @@ aliases = (
     ('9sus4',    'sus9',     '')
     )
 
-for a,b,d in aliases:
-    n=chordlist[b][0]
-    s=chordlist[b][1]
+for a, b, d in aliases:
+    n = chordlist[b][0]
+    s = chordlist[b][1]
     if not d:
-        d=chordlist[b][2]
+        d = chordlist[b][2]
 
     chordlist[a] = (n, s, d)
-

--- a/src/main/python/linuxband/mma/grooves.py
+++ b/src/main/python/linuxband/mma/grooves.py
@@ -55,7 +55,7 @@ class Grooves(object):
             return 1
         elif a == b:
             return 0
-        else: # x<y
+        else:  # x<y
             return -1
 
     def __create_grooves_model(self, grooves_list):
@@ -74,7 +74,7 @@ class Grooves(object):
                     or not groove[0].upper().startswith(pgroove) \
                     or groove[0].startswith('Metronome'):   # metronome hack    
                 sub_liststore = gtk.ListStore(str, str, str, str, str, str)
-                grooves_model.append(groove + [ sub_liststore ])
+                grooves_model.append(groove + [sub_liststore])
                 pgroove = groove[0].upper()
                 # March hack
                 if groove[0] == 'March':
@@ -99,7 +99,7 @@ class Grooves(object):
         """
         Load grooves and recurse into subdirectories.
         """
-        for dirname, dirnames, filenames in os.walk(path): #@UnusedVariable            
+        for dirname, dirnames, filenames in os.walk(path):
             for name in filenames:
                 if fnmatch.fnmatch(name, '*.mma'):
                     full_name = os.path.join(dirname, name)

--- a/src/main/python/linuxband/mma/parse.py
+++ b/src/main/python/linuxband/mma/parse.py
@@ -54,7 +54,7 @@ def parse(inpath):
 
         # EOF
         if not curline:
-            song_bar_info.append(bar_info) # song_bar_info has always one element more then song_bar_chords
+            song_bar_info.append(bar_info)  # song_bar_info has always one element more then song_bar_chords
             song_bar_count = bar_number
             return SongData(song_bar_info, song_bar_chords, song_bar_count)
 
@@ -64,7 +64,7 @@ def parse(inpath):
 
         # empty line
         if curline.rstrip('\n').strip() == '':
-            bar_info.add_line([Glob.A_UNKNOWN, curline]);
+            bar_info.add_line([Glob.A_UNKNOWN, curline])
             continue
 
         l = curline.split()
@@ -173,7 +173,7 @@ def parse(inpath):
         if wline[0].replace('\\\n', '').strip() == '':
             # line is a comment or empty wrapped line
             act = Glob.A_REMARK if wline[1].strip() else Glob.A_UNKNOWN
-            bar_info.add_line([act , wline[0], wline[1]])
+            bar_info.add_line([act, wline[0], wline[1]])
             continue
 
         l, eol = wline
@@ -245,9 +245,9 @@ def parse(inpath):
                         be at the end of bar in the form '* xx'.
                     """
                     pass
-                elif ch in '\t\n\\ 0123456789': # white spaces, \ and repeat count
+                elif ch in '\t\n\\ 0123456789':  # white spaces, \ and repeat count
                     pass
-                elif solo_count == 0 and lyrics_count == 0: # found beginning of the chord
+                elif solo_count == 0 and lyrics_count == 0:  # found beginning of the chord
                     break
                 chars += ch
                 i += 1
@@ -339,7 +339,7 @@ def get_wrapped_line_join(inpath, curline):
             else:
                 line = line + l
         i = i + 1
-    return [ line, comment ]
+    return [line, comment]
 
 
 def parse_begin_block(inpath, curline):
@@ -362,11 +362,12 @@ def parse_begin_block(inpath, curline):
             break
     return result
 
+
 def parse_mset_block(inpath, curline):
     l = curline.split()
     if len(l) < 2:
         raise ValueError("Use: MSET VARIABLE_NAME <lines> MsetEnd")
-    result = [ curline ]
+    result = [curline]
     while True:
         curline = inpath.readline()
         if not curline:
@@ -380,9 +381,10 @@ def parse_mset_block(inpath, curline):
             break
     return result
 
+
 def parse_if_block(inpath, curline):
     ifDepth = 1
-    result = [ curline ]
+    result = [curline]
     while True:
         curline = inpath.readline()
         if not curline:
@@ -399,6 +401,7 @@ def parse_if_block(inpath, curline):
         if ifDepth == 0:
             break
     return result
+
 
 def parse_supported_action(action, wline):
     line = []
@@ -420,6 +423,7 @@ def parse_supported_action(action, wline):
         line = tokenize_line(wline[0], 2)
     line.append(wline[1])
     return line
+
 
 def parse_supported_block_action(block_action, begin_block):
     return [ begin_block[0], ''.join(begin_block[1:-1]), begin_block[-1] ]

--- a/src/main/python/linuxband/mma/song.py
+++ b/src/main/python/linuxband/mma/song.py
@@ -101,7 +101,7 @@ class Song(object):
         
         bar_count = number of bar_chords in the song, number of bar_info is bar_count + 1
         """
-        self.__song_data = SongData([ BarInfo() ], [], 0)
+        self.__song_data = SongData([BarInfo()], [], 0)
         self.__invalid_mma_data = None
         self.__pending_mma_data = None
         self.__last_compile_result = None

--- a/src/main/python/linuxband/mma/song_data.py
+++ b/src/main/python/linuxband/mma/song_data.py
@@ -36,7 +36,7 @@ class SongData(object):
         self.__bar_info = bar_info
         self.__bar_chords = bar_chords
         self.__bar_count = bar_count
-        self.__beats_per_bar = 4 # TODO Beats/bar, set with TIME        
+        self.__beats_per_bar = 4  # TODO Beats/bar, set with TIME
         self.__save_needed = False
         for bar_info in self.__bar_info:
             bar_info.set_song_data(self)
@@ -78,7 +78,7 @@ class SongData(object):
         return self.__save_needed
 
     def changed(self):
-        logging.debug('Song changed');
+        logging.debug('Song changed')
         self.__save_needed = True
 
     def create_bar_info(self):
@@ -120,7 +120,7 @@ class SongData(object):
         if len(lines) > 0:
             if lines[0][0] == Glob.A_REMARK:
                 comm = lines[0][-1].strip()
-                comm = comm [2:] # remove '//'
+                comm = comm[2:]  # remove '//'
                 return comm.strip()
         return Glob.UNTITLED_SONG_NAME
 
@@ -159,7 +159,7 @@ class SongData(object):
             mma_array.extend(self.__bar_chords[i].get_as_string_list())
             if i == self.__bar_count - 1:
                 mma_array.extend("MidiMark END\n")
-            mma_array.extend("MSetEnd\n") # 5 lines
+            mma_array.extend("MSetEnd\n")  # 5 lines
         # write the song
         for i in range(0, self.__bar_count):
             mma_array.extend(self.__bar_info[i].get_as_string_list())


### PR DESCRIPTION
This commit introduces further cosmetic improvements by removing
semicola from the end of some statements, ensuring at least to white
spaces before an inline comment and deleting some unnecessary comments
and linter hints. Additionally, it removes white spaces inside braces
as well as brackets and adds the missing ones around some operators.