### PR TITLE
[PEP8] Remove some unused variables and linter comments.

### DIFF
--- a/src/main/python/linuxband/gui/chord_entries.py
+++ b/src/main/python/linuxband/gui/chord_entries.py
@@ -168,7 +168,7 @@ class ChordEntries(object):
 
         chord_names = []
         for c in base_ext:
-            for k, v in chordlist.iteritems(): #@UnusedVariable
+            for k in chordlist.iterkeys():
                 chord_names.append(c + k)
 
         chord_names.sort()

--- a/src/main/python/linuxband/gui/events/groove.py
+++ b/src/main/python/linuxband/gui/events/groove.py
@@ -39,7 +39,7 @@ class EventGroove(object):
 
     def on_treeview1_cursor_changed_callback(self, treeview):
         """ User clicked on the groove in the first column. """
-        path, column = treeview.get_cursor() #@UnusedVariable
+        path = treeview.get_cursor()[0]
         gr = self.__groovesModel[path[0]]
         self.__treeview2.set_model(gr[6])
         self.__update_groove_info(gr)
@@ -47,9 +47,9 @@ class EventGroove(object):
 
     def on_treeview2_cursor_changed_callback(self, treeview):
         """ User clicked on the variation of groove. """
-        path, column = self.__treeview1.get_cursor() #@UnusedVariable
+        path = self.__treeview1.get_cursor()[0]
         model = self.__groovesModel[path[0]][6]
-        path, column = self.__treeview2.get_cursor() #@UnusedVariable
+        path = self.__treeview2.get_cursor()[0]
         gr = model[path[0]]
         self.__update_groove_info(gr)
         self.__update_groove_event(gr[0])
@@ -115,7 +115,7 @@ class EventGroove(object):
         """ Update description, author ... of the currently selected groove. """
         tb = self.__textbuffer2
         tb.set_text('')
-        start, end = tb.get_bounds() #@UnusedVariable
+        end = tb.get_bounds()[1]
         tb.insert_with_tags_by_name(end, gr[0] + '\n', 'fg_brown', 'bold')
         tb.insert(end, gr[1] + '\n\n')
         tb.insert_with_tags_by_name(end, gr[2] + '\n\n', 'bold')

--- a/src/main/python/linuxband/gui/gui_logger.py
+++ b/src/main/python/linuxband/gui/gui_logger.py
@@ -52,7 +52,7 @@ class GuiLogger(object):
             logging.Formatter.__init__(self, fmt, datefmt)
 
         def formatException(self, ei):
-            excType, excValue, excTraceback = ei #@UnusedVariable
+            excType, excValue, _ = ei
             res = ''.join(traceback.format_exception_only(excType, excValue))
             if res[-1] == '\n':
                 res = res[:-1]

--- a/src/main/python/linuxband/mma/parse.py
+++ b/src/main/python/linuxband/mma/parse.py
@@ -145,7 +145,7 @@ def parse(inpath):
 
         # track function BASS/DRUM/APEGGIO/CHORD ...
         if '-' in action:
-            trk_class, ext = action.split('-', 1) #@UnusedVariable
+            trk_class = action.split('-', 1)[0]
         else:
             trk_class = action
 


### PR DESCRIPTION
This commit introduces some small changes to avoid instances of unused
variables. There are some more places in the code which might be cleaned
up by a later commit.